### PR TITLE
Increase max number of messages in SMS folder

### DIFF
--- a/include/gnokii/sms.h
+++ b/include/gnokii/sms.h
@@ -39,7 +39,7 @@
 
 /* Maximal number of SMS folders */
 #define GN_SMS_FOLDER_MAX_NUMBER       64
-#define GN_SMS_MESSAGE_MAX_NUMBER    1024
+#define GN_SMS_MESSAGE_MAX_NUMBER    2048
 
 #define GN_SMS_DATETIME_MAX_LENGTH      7
 #define GN_SMS_SMSC_NUMBER_MAX_LENGTH  20


### PR DESCRIPTION
Bump the value of GN_SMS_MESSAGE_MAX_NUMBER
from 1024 to 2048.

Without this change the number of messages
displayed may be wrong if it is above 1024.

Eg, without this change:

```
$ gnokii --showsmsfolderstatus
No. Name                                         Id #Msg
========================================================
  0 SMS Folder 1                                 F1    0
  1 SMS Inbox                                    IN 1024
```

With this change:

```
$ gnokii --showsmsfolderstatus
No. Name                                         Id #Msg
========================================================
  0 SMS Folder 1                                 F1    0
  1 SMS Inbox                                    IN 1234
```