### PR TITLE
FBUS exchange/file SMS sending/receiving

### DIFF
--- a/common/data/virtmodem.c
+++ b/common/data/virtmodem.c
@@ -325,7 +325,7 @@ static int gopen(const char *command)
    to be /dev/gnokii etc. ) */
 static int VM_PtySetup(const char *bindir)
 {
-	char mgnokiidev[200];
+	char mgnokiidev[256];
 
 	if (UseSTDIO) {
 		PtyRDFD = STDIN_FILENO;
@@ -333,14 +333,8 @@ static int VM_PtySetup(const char *bindir)
 		return (0);
 	}
 
-	if (bindir) {
-		strncpy(mgnokiidev, bindir, sizeof(mgnokiidev));
-		strncat(mgnokiidev, "/", sizeof(mgnokiidev) - strlen(mgnokiidev) - 1);
-	} else {
-		mgnokiidev[0] = 0;
-	}
-
-	strncat(mgnokiidev, "mgnokiidev", sizeof(mgnokiidev) - strlen(mgnokiidev) - 1);
+	snprintf(mgnokiidev, sizeof(mgnokiidev), "%s%smgnokiidev",
+		 bindir ? bindir : "", bindir ? "/" : "");
 
 	if (access(mgnokiidev, X_OK) != 0) {
 		fprintf(stderr, _("Cannot access %s, check the bindir in your config file!\n"), mgnokiidev);

--- a/common/device.c
+++ b/common/device.c
@@ -111,6 +111,10 @@ const static gn_device_ops _tekram_ops = {
 	tekram_select,
 	tekram_read,
 	tekram_write,
+	NULL,
+	NULL,
+	tekram_changespeed,
+	tekram_setdtrrts,
 };
 #define tekram_ops	&_tekram_ops
 

--- a/common/device.c
+++ b/common/device.c
@@ -193,6 +193,9 @@ void device_close(struct gn_statemachine *state)
 {
 	gn_device *device = &state->device;
 
+	if (!device->instance)
+		return;
+
 	dprintf("device: closing device\n");
 
 	/*

--- a/common/device.c
+++ b/common/device.c
@@ -28,6 +28,7 @@ const static gn_device_ops _bluetooth_ops = {
 	bluetooth_select,
 	bluetooth_read,
 	bluetooth_write,
+	bluetooth_getfd,
 };
 #  define bluetooth_ops	&_bluetooth_ops
 #else
@@ -56,6 +57,7 @@ const static gn_device_ops _irda_ops = {
 	irda_select,
 	irda_read,
 	irda_write,
+	irda_getfd,
 };
 #  define irda_ops	&_irda_ops
 #else
@@ -69,6 +71,7 @@ const static gn_device_ops _serial_ops = {
 	serial_select,
 	serial_read,
 	serial_write,
+	serial_getfd,
 	serial_nreceived,
 	serial_flush,
 	serial_changespeed,
@@ -84,6 +87,7 @@ const static gn_device_ops _phonet_ops = {
 	socketphonet_select,
 	socketphonet_read,
 	socketphonet_write,
+	socketphonet_getfd,
 };
 #  define phonet_ops	&_phonet_ops
 #else
@@ -98,6 +102,7 @@ const static gn_device_ops _tcp_ops = {
 	tcp_select,
 	tcp_read,
 	tcp_write,
+	tcp_getfd,
 };
 #  define tcp_ops	&_tcp_ops
 #else
@@ -111,6 +116,7 @@ const static gn_device_ops _tekram_ops = {
 	tekram_select,
 	tekram_read,
 	tekram_write,
+	tekram_getfd,
 	NULL,
 	NULL,
 	tekram_changespeed,
@@ -120,7 +126,12 @@ const static gn_device_ops _tekram_ops = {
 
 GNOKII_API int device_getfd(struct gn_statemachine *state)
 {
-	return state->device.fd;
+	gn_device *device = &state->device;
+
+	if (device->ops->getfd && device->instance)
+		return device->ops->getfd(device->instance);
+
+	return -1;
 }
 
 int device_open(int with_odd_parity, int with_async,
@@ -175,12 +186,11 @@ int device_open(int with_odd_parity, int with_async,
 		return 0;
 
 	device->type = device_type;
-	device->fd = *(int *)(device->instance);
 
 	/*
 	 * handle config file connect_script:
 	 */
-	if (device_script(device->fd, 1, state)) {
+	if (device_script(device_getfd(state), 1, state)) {
 		dprintf("gnokii open device: connect_script failure\n");
 		device_close(state);
 		return 0;
@@ -201,14 +211,13 @@ void device_close(struct gn_statemachine *state)
 	/*
 	 * handle config file disconnect_script:
 	 */
-	if (device_script(device->fd, 0, state))
+	if (device_script(device_getfd(state), 0, state))
 		dprintf("gnokii device close: disconnect_script failure\n");
 
 	device->ops->close(device->instance);
 	free(device->instance);
 	device->instance = NULL;
 	device->type = GN_CT_NONE;
-	device->fd = -1;
 }
 
 void device_setdtrrts(int dtr, int rts, struct gn_statemachine *state)

--- a/common/devices/dku2libusb.c
+++ b/common/devices/dku2libusb.c
@@ -480,8 +480,7 @@ void* fbusdku2usb_open(gn_config *cfg, int with_odd_parity, int with_async)
 	if (iface) {
 		if (usbfbus_connect_request(iface))
 			return iface;
-		else
-			free(iface);
+		usbfbus_free_interfaces(iface);
 	}
 
 	return NULL;

--- a/common/devices/osxbluetooth.m
+++ b/common/devices/osxbluetooth.m
@@ -153,3 +153,9 @@ void bluetooth_close(void *instance)
     GnokiiOSXBluetooth *q = instance;
     [q release];
 }
+
+int bluetooth_getfd(void *instance)
+{
+    /* FIXME: Any way to get a file descriptor from IOBluetooth object? */
+    return -1;
+}

--- a/common/devices/socketphonet.c
+++ b/common/devices/socketphonet.c
@@ -87,6 +87,11 @@ void socketphonet_close(void *instance)
 	close(*(int *)instance);
 }
 
+int socketphonet_getfd(void *instance)
+{
+	return *(int *)instance;
+}
+
 
 size_t socketphonet_read(void *instance, __ptr_t buf, size_t nbytes)
 {

--- a/common/devices/tcp.c
+++ b/common/devices/tcp.c
@@ -185,6 +185,11 @@ void tcp_close(void *instance)
 	close(*(int *)instance);
 }
 
+int tcp_getfd(void *instance)
+{
+	return *(int *)instance;
+}
+
 extern int unix_select(int fd, struct timeval *timeout);
 
 int tcp_select(void *instance, struct timeval *timeout)

--- a/common/devices/tekram.c
+++ b/common/devices/tekram.c
@@ -41,7 +41,27 @@ void tekram_close(void *instance)
 	serial_close(instance);
 }
 
-void tekram_reset(void *instance)
+int tekram_select(void *instance, struct timeval *timeout)
+{
+	return serial_select(instance, timeout);
+}
+
+size_t tekram_read(void *instance, __ptr_t buf, size_t nbytes)
+{
+	return serial_read(instance, buf, nbytes);
+}
+
+size_t tekram_write(void *instance, const __ptr_t buf, size_t n)
+{
+	return serial_write(instance, buf, n);
+}
+
+int tekram_getfd(void *instance)
+{
+	return serial_getfd(instance);
+}
+
+static void tekram_reset(void *instance)
 {
 	serial_setdtrrts(instance, 0, 0);
 	usleep(50000);
@@ -52,7 +72,7 @@ void tekram_reset(void *instance)
 	serial_changespeed(instance, 9600);
 }
 
-void tekram_changespeed(void *instance, int speed)
+gn_error tekram_changespeed(void *instance, int speed)
 {
 	unsigned char speedbyte;
 	switch (speed) {
@@ -69,20 +89,10 @@ void tekram_changespeed(void *instance, int speed)
 	serial_write(instance, &speedbyte, 1);
 	usleep(100000);
 	serial_setdtrrts(instance, 1, 1);
-	serial_changespeed(instance, speed);
+	return serial_changespeed(instance, speed);
 }
 
-size_t tekram_read(void *instance, __ptr_t buf, size_t nbytes)
+void tekram_setdtrrts(void *instance, int dtr, int rts)
 {
-	return serial_read(instance, buf, nbytes);
-}
-
-size_t tekram_write(void *instance, const __ptr_t buf, size_t n)
-{
-	return serial_write(instance, buf, n);
-}
-
-int tekram_select(void *instance, struct timeval *timeout)
-{
-	return serial_select(instance, timeout);
+	return serial_setdtrrts(instance, dtr, rts);
 }

--- a/common/devices/unixbluetooth.c
+++ b/common/devices/unixbluetooth.c
@@ -528,6 +528,11 @@ void bluetooth_close(void *instance)
 	close(*(int *)instance);
 }
 
+int bluetooth_getfd(void *instance)
+{
+	return *(int *)instance;
+}
+
 size_t bluetooth_write(void *instance, const __ptr_t bytes, size_t size)
 {
 	return write(*(int *)instance, bytes, size);

--- a/common/devices/unixirda.c
+++ b/common/devices/unixirda.c
@@ -159,6 +159,11 @@ void irda_close(void *instance)
 	close(fd);
 }
 
+int irda_getfd(void *instance)
+{
+	return *(int *)instance;
+}
+
 size_t irda_write(void *instance, const __ptr_t bytes, size_t size)
 {
 	return send(*(int *)instance, bytes, size, 0);

--- a/common/devices/unixserial.c
+++ b/common/devices/unixserial.c
@@ -224,6 +224,11 @@ void serial_close(void *instance)
 	close(THIS(fd));
 }
 
+int serial_getfd(void *instance)
+{
+	return THIS(fd);
+}
+
 /* Set the DTR and RTS bit of the serial device. */
 void serial_setdtrrts(void *instance, int dtr, int rts)
 {

--- a/common/devices/unixserial.c
+++ b/common/devices/unixserial.c
@@ -159,15 +159,13 @@ void* serial_open(gn_config *cfg, int with_odd_parity, int with_async)
 	ret = tcflush(data->fd, TCIFLUSH);
 	if (ret == -1) {
 		perror("Gnokii serial_opendevice: tcflush");
-		serial_close(data);
-		return NULL;
+		goto bail;
 	}
 
 	ret = tcsetattr(data->fd, TCSANOW, &tp);
 	if (ret == -1) {
 		perror("Gnokii serial_opendevice: tcsetattr");
-		serial_close(data);
-		return NULL;
+		goto bail;
 	}
 
 	if (serial_changespeed(data, cfg->serial_baudrate) != GN_ERR_NONE)
@@ -178,8 +176,7 @@ void* serial_open(gn_config *cfg, int with_odd_parity, int with_async)
 	ret = fcntl(data->fd, F_SETOWN, getpid());
 	if (ret == -1) {
 		perror("Gnokii serial_opendevice: fcntl(F_SETOWN)");
-		serial_close(data);
-		return NULL;
+		goto bail;
 	}
 #endif
 
@@ -202,14 +199,17 @@ void* serial_open(gn_config *cfg, int with_odd_parity, int with_async)
 #endif
 		if (ret == -1) {
 			perror("Gnokii serial_opendevice: fcntl(F_SETFL)");
-			serial_close(data);
-			return NULL;
+			goto bail;
 		}
 	}
 	data->write_usleep = cfg->serial_write_usleep;
 	data->require_dcd = cfg->require_dcd;
 
 	return data;
+bail:
+	serial_close(data);
+	free(data);
+	return NULL;
 }
 
 

--- a/common/devices/winbluetooth.c
+++ b/common/devices/winbluetooth.c
@@ -93,6 +93,11 @@ void bluetooth_close(void *instance)
 	WSACleanup();
 }
 
+int bluetooth_getfd(void *instance)
+{
+	return (int)*(SOCKET *)instance;
+}
+
 size_t bluetooth_write(void *instance, const __ptr_t bytes, size_t size)
 {
 	return send(*(SOCKET *)instance, bytes, size, 0);

--- a/common/devices/winirda.c
+++ b/common/devices/winirda.c
@@ -146,6 +146,11 @@ void irda_close(void *instance)
 	WSACleanup();
 }
 
+int irda_getfd(void *instance)
+{
+	return (int)*(SOCKET *)instance;
+}
+
 size_t irda_write(void *instance, const __ptr_t bytes, size_t size)
 {
 	return send(*(SOCKET *)instance, bytes, size, 0);

--- a/common/devices/winirda.c
+++ b/common/devices/winirda.c
@@ -99,14 +99,13 @@ void* irda_open(gn_config *cfg, int with_odd_parity, int with_async)
 	if ((fd = socket(AF_IRDA, SOCK_STREAM, 0)) < 0) {
 		perror("socket");
 		dprintf("Failed to create an irda socket.\n");
-		return NULL;
+		goto bail_wsa;
 	}
 	/* Discover devices */
 	daddr = irda_discover_device(cfg->irda_string, fd); /* discover the devices */
 	if (daddr == INVALID_DADDR) {
 		dprintf("Failed to discover any irda device.\n");
-		closesocket(fd);
-		return NULL;
+		goto bail_socket;
 	}
 	/* Prepare socket structure for irda socket */
 	peer.irdaAddressFamily = AF_IRDA;
@@ -116,8 +115,7 @@ void* irda_open(gn_config *cfg, int with_odd_parity, int with_async)
 		if (setsockopt(fd, SOL_IRLMP, IRLMP_9WIRE_MODE, (char *)&x, sizeof(x)) == SOCKET_ERROR) {
 			perror("setsockopt");
 			dprintf("Failed to set irda socket options.\n");
-			closesocket(fd);
-			return NULL;
+			goto bail_socket;
 		}
 	} else
 		snprintf(peer.irdaServiceName, sizeof(peer.irdaServiceName), "Nokia:PhoNet");
@@ -125,17 +123,20 @@ void* irda_open(gn_config *cfg, int with_odd_parity, int with_async)
 	if (connect(fd, (struct sockaddr *)&peer, sizeof(peer))) {	/* Connect to service "Nokia:PhoNet" */
 		perror("connect");
 		dprintf("Failed to connect to irda socket\n");
-		closesocket(fd);
-		return NULL;
+		goto bail_socket;
 	}
 	data = malloc(sizeof(SOCKET));
-	if (data == NULL) {
-		closesocket(fd);
-		return NULL;
-	}
+	if (data == NULL)
+		goto bail_socket;
 	*data = fd;
 
 	return data;
+
+bail_socket:
+	closesocket(fd);
+bail_wsa:
+	WSACleanup();
+	return NULL;
 }
 
 void irda_close(void *instance)

--- a/common/devices/winserial.c
+++ b/common/devices/winserial.c
@@ -305,6 +305,12 @@ size_t serial_write(void *instance, __ptr_t buf, size_t n)
 	return n;
 }
 
+int serial_getfd(void *instance)
+{
+	/* the device is a HANDLE, but this is close enough */
+	return (int)*(HANDLE *)instance;
+}
+
 gn_error serial_nreceived(void *instance, int *n)
 {
 	return GN_ERR_NONE;

--- a/common/gsm-networks.c
+++ b/common/gsm-networks.c
@@ -1289,8 +1289,7 @@ GNOKII_API char *gn_network_code_find(char *network_name, char *country_name)
 	int index = 0;
 	char country_code[5];
 
-	snprintf(country_code, 4, "%3s ", gn_country_code_get(country_name));
-	country_code[4] = 0;
+	snprintf(country_code, sizeof(country_code), "%3s ", gn_country_code_get(country_name));
 	while (networks[index].name &&
 	       (!strstr(networks[index].code, country_code) ||
 	        strcasecmp(networks[index].name, network_name))) index++;

--- a/common/gsm-sms.c
+++ b/common/gsm-sms.c
@@ -146,7 +146,7 @@ static char *sms_timestamp_print(uint8_t *number)
 			c = ' ';
 			break;
 		}
-		snprintf(buf2, 4, "%d%d%c", number[i] & 0x0f, number[i] >> 4, c);
+		snprintf(buf2, sizeof(buf2), "%d%d%c", number[i] & 0x0f, number[i] >> 4, c);
 		strncat(buffer, buf2, sizeof(buffer) - strlen(buffer) - 1);
 	}
 
@@ -1641,7 +1641,7 @@ static void sms_dump_raw(gn_sms_raw *rawsms)
 #ifdef DEBUG
 	char buf[10240];
 
-	memset(buf, 0, 10240);
+	memset(buf, 0, sizeof(buf));
 
 	dprintf("dcs: 0x%02x\n", rawsms->dcs);
 	dprintf("Length: 0x%02x\n", rawsms->length);
@@ -2276,7 +2276,7 @@ GNOKII_API char *gn_sms2mbox(gn_sms *sms, char *from)
 	APPEND((BUFP, "X-GSM-Memory: %s\n", gn_memory_type2str(sms->memory_type)));
 
 	/* assuming location will never have more than 15 digits */
-	snprintf(str, 15, "%d", sms->number);
+	snprintf(str, sizeof(str), "%d", sms->number);
 	APPEND((BUFP, "X-GSM-Location: %s\n", str));
 
 	if (strlen(sms->user_data[0].u.text) < MAX_SUBJECT_LENGTH) {

--- a/common/gsm-sms.c
+++ b/common/gsm-sms.c
@@ -825,6 +825,153 @@ gn_error gn_sms_parse(gn_data *data)
 	return sms_pdu_decode(data->raw_sms, data->sms);
 }
 
+/*
+ * TP field layout for each message type (order of the TP elements), driving the
+ * PDU encoder gn_sms_raw2pdu(). The numbers are the TP-* field ids handled in
+ * its switch statement.
+ */
+static const int sms_pdu_deliver[]       = {2, 17, 23, 4, 7, 9, 10, 11, 16, 24, -1};
+static const int sms_pdu_submit[]        = {25, 3, 17, 23, 5, 6, 8, 9, 10, 12, 16, 24, -1};
+static const int sms_pdu_status_report[] = {23, 2, 26, 6, 14, 11, 13, 15, 27, 9, 10, 16, 24, -1};
+
+/* number of bytes an address field occupies (type byte + packed digits) */
+static unsigned char sms_pdu_address_length(const unsigned char *addr)
+{
+	if (!addr[0])
+		return 0;
+	return (addr[0] + 1) / 2 + 1;
+}
+
+/**
+ * gn_sms_raw2pdu - Encode a gn_sms_raw structure into a PDU
+ * @buf: output buffer (must hold *len bytes)
+ * @len: in: buffer size; out: encoded PDU length
+ * @rawsms: the raw SMS to encode
+ * @flags: GN_SMS_PDU_* flags; GN_SMS_PDU_NOSMSC omits the SMSC prefix
+ *
+ * The counterpart of gn_sms_pdu2raw(): builds an SMS PDU from the raw values,
+ * driven by the per-type field-layout tables above.
+ */
+gn_error gn_sms_raw2pdu(unsigned char *buf, int *len, const gn_sms_raw *rawsms, int flags)
+{
+	unsigned char *pos, *fpos, first_octet;
+	const int *pdu_format;
+	int i, l;
+
+	memset(buf, 0, *len);
+	pos = buf;
+
+	/* SMSC address, unless the caller wants a bare TPDU. The stored
+	   message_center is already an octet-length-prefixed field, which is
+	   exactly the standard PDU representation. */
+	if (!(flags & GN_SMS_PDU_NOSMSC)) {
+		int l = rawsms->message_center[0] + 1;
+
+		if (l > *len)
+			return GN_ERR_FAILED;
+		memcpy(pos, rawsms->message_center, l);
+		pos += l;
+	}
+
+	/* first octet (filled in once all flag-bearing fields are seen) */
+	fpos = pos++;
+	first_octet = rawsms->type >> 1;
+	switch (rawsms->type) {
+	case GN_SMS_MT_Deliver:      pdu_format = sms_pdu_deliver; break;
+	case GN_SMS_MT_Submit:       pdu_format = sms_pdu_submit; break;
+	case GN_SMS_MT_StatusReport: pdu_format = sms_pdu_status_report; break;
+	default: return GN_ERR_FAILED;
+	}
+
+	for (i = 0; pdu_format[i] > 0; i++) {
+		switch (pdu_format[i]) {
+		case 2: /* TP-MMS */
+			if (rawsms->more_messages) first_octet |= 0x04;
+			break;
+		case 3: /* TP-VPF */
+			first_octet |= rawsms->validity_indicator << 3;
+			break;
+		case 4: /* TP-SRI */
+		case 5: /* TP-SRR */
+		case 26:/* TP-SRQ */
+			if (rawsms->report) first_octet |= 0x20;
+			break;
+		case 6: /* TP-MR */
+			*pos++ = rawsms->reference;
+			break;
+		case 7: /* TP-OA */
+		case 8: /* TP-DA */
+		case 14:/* TP-RA */
+			l = sms_pdu_address_length(rawsms->remote_number) + 1;
+			if (l <= 0 || (size_t)l > sizeof(rawsms->remote_number))
+				return GN_ERR_FAILED;
+			memcpy(pos, rawsms->remote_number, l);
+			pos += l;
+			break;
+		case 9: /* TP-PID */
+			*pos++ = rawsms->pid;
+			break;
+		case 10:/* TP-DCS */
+			*pos++ = rawsms->dcs;
+			break;
+		case 11:/* TP-SCTS */
+			memcpy(pos, rawsms->smsc_time, 7);
+			pos += 7;
+			break;
+		case 12:/* TP-VP */
+			switch (rawsms->validity_indicator) {
+			case GN_SMS_VP_None: l = 0; break;
+			case GN_SMS_VP_RelativeFormat: l = 1; break;
+			default: l = 7; break;
+			}
+			memcpy(pos, rawsms->validity, l);
+			pos += l;
+			break;
+		case 13:/* TP-DT */
+			memcpy(pos, rawsms->time, 7);
+			pos += 7;
+			break;
+		case 15:/* TP-ST */
+		case 22:/* TP-FCS */
+			*pos++ = rawsms->report_status;
+			break;
+		case 16:/* TP-UDL */
+		case 20:/* TP-CDL */
+			*pos++ = rawsms->length;
+			break;
+		case 17:/* TP-RP */
+			if (rawsms->reply_via_same_smsc) first_octet |= 0x80;
+			break;
+		case 18:/* TP-MN */
+			*pos++ = rawsms->number;
+			break;
+		case 19:/* TP-CT */
+			pos++; /* unused */
+			break;
+		case 21:/* TP-CD */
+		case 24:/* TP-UD */
+			if ((int) rawsms->user_data_length > *len - (int)(pos - buf))
+				return GN_ERR_FAILED;
+			memcpy(pos, rawsms->user_data, rawsms->user_data_length);
+			pos += rawsms->user_data_length;
+			break;
+		case 23:/* TP-UDHI */
+			if (rawsms->udh_indicator) first_octet |= 0x40;
+			break;
+		case 25:/* TP-RD */
+			if (rawsms->reject_duplicates) first_octet |= 0x04;
+			break;
+		case 27:/* TP-PI */
+			pos++; /* unused */
+			break;
+		}
+	}
+	*fpos = first_octet;
+	*len = pos - buf;
+
+	return GN_ERR_NONE;
+}
+
 /**
  * gn_sms_pdu2raw - Copy PDU data into gn_sms_raw structure
  * @rawsms: gn_sms_raw structure to be filled

--- a/common/links/fbus-phonet.c
+++ b/common/links/fbus-phonet.c
@@ -139,10 +139,8 @@ static void phonet_rx_statemachine(unsigned char rx_byte, struct gn_statemachine
 		i->message_source = rx_byte;
 		i->state = FBUS_RX_GetType;
 
-		if (rx_byte != FBUS_DEVICE_PHONE) {
-			i->state = FBUS_RX_Sync;
-			dprintf("The fbus stream is out of sync - expected 0x00, got 0x%02x\n", rx_byte);
-		}
+		if (rx_byte != FBUS_DEVICE_PHONE)
+			dprintf("Non-standard source device 0x%02x\n", rx_byte);
 
 		break;
 
@@ -159,7 +157,7 @@ static void phonet_rx_statemachine(unsigned char rx_byte, struct gn_statemachine
 		break;
 
 	case FBUS_RX_GetLength2:
-		i->message_length = i->message_length + rx_byte;
+		i->message_length |= rx_byte;
 		i->state = FBUS_RX_GetMessage;
 		i->buffer_count = 0;
 		if (!verify_max_message_len(i->message_length, i)) {
@@ -180,8 +178,7 @@ static void phonet_rx_statemachine(unsigned char rx_byte, struct gn_statemachine
 			i->buffer_count++;
 		}
 
-		i->message_buffer[i->buffer_count] = rx_byte;
-		i->buffer_count++;
+		i->message_buffer[i->buffer_count++] = rx_byte;
 
 		/* Is that it? */
 		if (i->buffer_count == i->message_length) {

--- a/common/misc.c
+++ b/common/misc.c
@@ -473,12 +473,7 @@ GNOKII_API char *gn_device_lock(const char* port)
 		fprintf(stderr, _("Out of memory error while locking device.\n"));
 		return NULL;
 	}
-	/*
-	 * I think we don't need to use strncpy, as we should have enough
-	 * buffer due to strlen results, but it's safer to do so...
-	 */
-	strncpy(lock_file, lock_path, len);
-	strncat(lock_file, aux, len - strlen(lock_file));
+	snprintf(lock_file, len + 1, "%s%s", lock_path, aux);
 
 	/* Check for the stale lockfile.
 	 * The code taken from minicom by Miquel van Smoorenburg */

--- a/common/misc.c
+++ b/common/misc.c
@@ -320,7 +320,7 @@ static gn_phone_model models[] = {
 	{"RPM-1", "RPM-1",	PM_OLD_DEFAULT | PM_DATA },
 	{"C1-01", "RM-607",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition Lite */
 	{"C1-02", "RM-643",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition Lite */
-	{"C2-03", "RM-70",	PM_DEFAULT_S40_3RD },
+	{"C2-03", "RM-702",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition feature pack 1 */
 	{"Card Phone 1.0", "RPE-1",	PM_OLD_DEFAULT | PM_DATA },
 	{"Card Phone 2.0", "RPM-1",	PM_OLD_DEFAULT | PM_DATA },
 	{"C110 Wireless LAN Card", "DTN-10",	PM_OLD_DEFAULT },

--- a/common/misc.c
+++ b/common/misc.c
@@ -320,6 +320,7 @@ static gn_phone_model models[] = {
 	{"RPM-1", "RPM-1",	PM_OLD_DEFAULT | PM_DATA },
 	{"C1-01", "RM-607",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition Lite */
 	{"C1-02", "RM-643",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition Lite */
+	{"C2-00", "RM-704",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition Lite */
 	{"C2-03", "RM-702",	PM_DEFAULT_S40_3RD },  /* Series 40 6th Edition feature pack 1 */
 	{"Card Phone 1.0", "RPE-1",	PM_OLD_DEFAULT | PM_DATA },
 	{"Card Phone 2.0", "RPM-1",	PM_OLD_DEFAULT | PM_DATA },

--- a/common/phones/atbosch.c
+++ b/common/phones/atbosch.c
@@ -72,11 +72,11 @@ static gn_error ReplyGetSMS(int type, unsigned char *buffer, int length,
 	/* Do we need one more digit? */
 	if (len / 10 < (len + 2) / 10)
 		memmove(lenpos + 1, lenpos, lenpos - (char*)buffer);
-	ofs = snprintf(tmp, 8, "%d", len + 2);
+	ofs = snprintf(tmp, sizeof(tmp), "%d", len + 2);
 	if (ofs < 1)
 		return GN_ERR_INTERNALERROR; /* something went very wrong */
 	memcpy(lenpos, tmp, ofs);
-	
+
 	/* Insert zero length SMSC field */
 	ofs = pos - (char*)buffer;
 	memmove(pos + 2, pos, length - ofs);

--- a/common/phones/atgen.c
+++ b/common/phones/atgen.c
@@ -933,7 +933,7 @@ static gn_error AT_GetBattery(gn_data *data, struct gn_statemachine *state)
 	at_driver_instance *drvinst = AT_DRVINST(state);
 	char key[4];
 
-	snprintf(key, 4, "CBC");
+	snprintf(key, sizeof(key), "CBC");
 	if (map_get(&drvinst->cached_capabilities, key, 1))
 		return Parse_ReplyGetBattery(data, state);
 	else if (sm_message_send(7, GN_OP_GetBatteryLevel, "AT+CBC\r", state))
@@ -966,7 +966,7 @@ static gn_error AT_GetMemoryRange(gn_data *data, struct gn_statemachine *state)
 	gn_error ret;
 	char key[7];
 
-	snprintf(key, 7, "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
+	snprintf(key, sizeof(key), "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
 	if (map_get(&drvinst->cached_capabilities, key, 0)) {
 		ret = Parse_ReplyMemoryRange(data, state);
 	} else {
@@ -1563,7 +1563,7 @@ static gn_error AT_EnterSecurityCode(gn_data *data, struct gn_statemachine *stat
 
 static gn_error AT_DialVoice(gn_data *data, struct gn_statemachine *state)
 {
-	unsigned char req[32];
+	unsigned char req[GN_PHONEBOOK_NUMBER_MAX_LENGTH + 8]; /* "ATD" + number + ";\r" + \0 */
 
 	if (!data->call_info)
 		return GN_ERR_INTERNALERROR;
@@ -1949,9 +1949,8 @@ static gn_error ReplyReadPhonebookExt(int messagetype, unsigned char *buffer, in
 {
 	at_driver_instance *drvinst = AT_DRVINST(state);
 	at_line_buffer buf;
-	char *pos, *first_name, *last_name, *tmp;
+	char *pos, *first_name, *last_name;
 	gn_error error;
-	size_t len = 0;
 
 	if ((error = at_error_get(buffer, state)) != GN_ERR_NONE)
 		return (error == GN_ERR_UNKNOWN) ? GN_ERR_INVALIDLOCATION : error;
@@ -2001,32 +2000,11 @@ static gn_error ReplyReadPhonebookExt(int messagetype, unsigned char *buffer, in
 		/* compile a name out of first name + last name */
 		first_name = extpb_find_subentry(entry, GN_PHONEBOOK_ENTRY_FirstName);
 		last_name = extpb_find_subentry(entry, GN_PHONEBOOK_ENTRY_LastName);
-		if (first_name || last_name) {
-			if (first_name)
-				len += strlen(first_name);
-			if (last_name)
-				len += strlen(last_name);
-			if (!(tmp = (char *)malloc(len + 2))) /* +2 for \0 and space */
-				return GN_ERR_INTERNALERROR;
-			tmp[0] = 0;
-			if (first_name) {
-				if (strlen(first_name) + strlen(entry->name) + 1 > sizeof(entry->name)) {
-					free(tmp);
-					return GN_ERR_FAILED;
-				}
-				strncat(entry->name, first_name, strlen(first_name));
-				if (last_name)
-					strncat(entry->name, " ", strlen(" "));
-			}
-			if (last_name) {
-				if (strlen(last_name) + strlen(entry->name) + 1 > sizeof(entry->name)) {
-					free(tmp);
-					return GN_ERR_FAILED;
-				}
-				strncat(entry->name, last_name, strlen (last_name));
-			}
-			free(tmp);
-		}
+		if (snprintf(entry->name, sizeof(entry->name), "%s%s%s",
+			     first_name ? first_name : "",
+			     first_name && last_name ? " " : "",
+			     last_name ? last_name : "") >= (int)sizeof(entry->name))
+			return GN_ERR_FAILED;
 	}
 	return GN_ERR_NONE;
 }
@@ -2115,7 +2093,7 @@ static gn_error Parse_ReplyMemoryRange(gn_data *data, struct gn_statemachine *st
 	char *r, *s, *t, *pos;
 	char key[7];
 
-	snprintf(key, 7, "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
+	snprintf(key, sizeof(key), "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
 	r = strdup(map_get(&drvinst->cached_capabilities, key, 0));
 	s = r + 7;
 	pos = strchr(s, ',');
@@ -2163,7 +2141,7 @@ static gn_error ReplyMemoryRange(int messagetype, unsigned char *buffer, int len
 
 	if (strncmp(buf.line2, "+CPBR: ", 7) == 0) {
 		char key[7];
-		snprintf(key, 7, "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
+		snprintf(key, sizeof(key), "%s%s", "CPBR", gn_memory_type2str(drvinst->memorytype));
 		map_add(&drvinst->cached_capabilities, strdup(key), strdup(buf.line2));
 		Parse_ReplyMemoryRange(data, state);
 	}
@@ -2182,7 +2160,7 @@ static gn_error Parse_ReplyGetBattery(gn_data *data, struct gn_statemachine *sta
 	const char *line, *pos;
 	char key[4];
 
-	snprintf(key, 4, "CBC");
+	snprintf(key, sizeof(key), "CBC");
 	line = map_get(&drvinst->cached_capabilities, key, 1);
 	if (data->battery_level) {
 		if (data->battery_unit)
@@ -2237,7 +2215,7 @@ static gn_error ReplyGetBattery(int messagetype, unsigned char *buffer, int leng
 
 	if (!strncmp(buf.line1, "AT+CBC", 6) && !strncmp(buf.line2, "+CBC: ", 6)) {
 		char key[4];
-		snprintf(key, 4, "CBC");
+		snprintf(key, sizeof(key), "CBC");
 		map_add(&drvinst->cached_capabilities, strdup(key), strdup(buf.line2));
 		Parse_ReplyGetBattery(data, state);
 	}
@@ -2696,7 +2674,7 @@ static gn_error ReplyRing(int messagetype, unsigned char *buffer, int length, gn
 			}
 		}
 
-		if (cinfo.name == NULL)
+		if (cinfo.name[0] == '\0')
 			snprintf(cinfo.name, GN_PHONEBOOK_NAME_MAX_LENGTH, _("Unknown"));
 		cinfo.type = drvinst->last_call_type;
 		drvinst->call_notification(drvinst->last_call_status, &cinfo, state, drvinst->call_callback_data);
@@ -3089,7 +3067,7 @@ static gn_error ReplyGetDateTime(int messagetype, unsigned char *buffer, int len
 	splitlines(&buf);
 
 	dt = data->datetime;
-	memset(timezone, 0, 6);
+	memset(timezone, 0, sizeof(timezone));
 	/* Use strip_quotes() since some phones do not use quotes. Add 7 to skip "+CCLK: " */
 	cnt = sscanf(strip_quotes(buf.line2 + 7), "%d/%d/%d,%d:%d:%d%[+-1234567890]",
 		     &dt->year, &dt->month, &dt->day,

--- a/common/phones/atgen.c
+++ b/common/phones/atgen.c
@@ -1406,7 +1406,7 @@ static gn_error AT_WriteSMS(gn_data *data, struct gn_statemachine *state,
 {
 	unsigned char req[10240], req2[5120];
 	gn_error error;
-	unsigned int length, tmp, offset = 0;
+	int length = sizeof(req2);
 	at_driver_instance *drvinst = AT_DRVINST(state);
 
 	if (!data->raw_sms)
@@ -1420,50 +1420,17 @@ static gn_error AT_WriteSMS(gn_data *data, struct gn_statemachine *state,
 	}
 	dprintf("PDU mode set\n");
 
-	/* Prepare the message and count the size */
-	if (drvinst->no_smsc) {
-		/* not even a length byte included */
-		offset--;
-	} else {
-		memcpy(req2, data->raw_sms->message_center,
-		       data->raw_sms->message_center[0] + 1);
-		offset += data->raw_sms->message_center[0];
-	}
-	/* Validity period in relative format */
-	req2[offset + 1] = 0x01 | 0x10;
-	if (data->raw_sms->reject_duplicates)
-		req2[offset + 1] |= 0x04;
-	if (data->raw_sms->report)
-		req2[offset + 1] |= 0x20;
-	if (data->raw_sms->udh_indicator)
-		req2[offset + 1] |= 0x40;
-	if (data->raw_sms->reply_via_same_smsc)
-		req2[offset + 1] |= 0x80;
-	req2[offset + 2] = 0x00; /* Message Reference */
-
-	tmp = data->raw_sms->remote_number[0];
-	if (tmp % 2)
-		tmp++;
-	tmp /= 2;
-	memcpy(req2 + offset + 3, data->raw_sms->remote_number, tmp + 2);
-	offset += tmp + 1;
-
-	req2[offset + 4] = data->raw_sms->pid;
-	req2[offset + 5] = data->raw_sms->dcs;
-	req2[offset + 6] = data->raw_sms->validity[0]; /* Validity period in relative format takes 1 octect */
-	req2[offset + 7] = data->raw_sms->length;
-	memcpy(req2 + offset + 8, data->raw_sms->user_data,
-	       data->raw_sms->user_data_length);
-
-	length = data->raw_sms->user_data_length + offset + 8;
+	/* Prepare the message; omit the SMSC prefix if the phone wants none */
+	error = gn_sms_raw2pdu(req2, &length, data->raw_sms,
+			       drvinst->no_smsc ? GN_SMS_PDU_NOSMSC : 0);
+	if (error)
+		return error;
 
 	/* Length in AT mode is the length of the full message minus
 	 * SMSC field length */
-	if (drvinst->no_smsc) {
-		snprintf(req, sizeof(req), "AT+%s=%d\r", cmd, length);
-	} else {
-		snprintf(req, sizeof(req), "AT+%s=%d\r", cmd, length - data->raw_sms->message_center[0] - 1);
-	}
+	snprintf(req, sizeof(req), "AT+%s=%d\r", cmd, drvinst->no_smsc ?
+		length : length - data->raw_sms->message_center[0] - 1);
+
 	dprintf("Sending initial sequence\n");
 	if (sm_message_send(strlen(req), GN_OP_AT_Prompt, req, state))
 		return GN_ERR_NOTREADY;

--- a/common/phones/gnapplet.c
+++ b/common/phones/gnapplet.c
@@ -141,141 +141,6 @@ gn_driver driver_gnapplet = {
 	NULL
 };
 
-static int pdu_deliver[] = {2, 17, 23, 4, 7, 9, 10, 11, 16, 24, -1};
-static int pdu_submit[] = {25, 3, 17, 23, 5, 6, 8, 9, 10, 12, 16, 24, -1};
-static int pdu_status_report[] = {23, 2, 26, 6, 14, 11, 13, 15, 27, 9, 10, 16, 24, -1};
-
-
-static unsigned char gnapplet_get_addrlen(const unsigned char *addr)
-{
-	if (!addr[0]) return 0;
-
-	return (addr[0] + 1) / 2 + 1;
-}
-
-
-static unsigned char gnapplet_get_semi(const unsigned char *addr)
-{
-	int l;
-
-	if (!addr[0]) return 0;
-
-	l = 2 * (addr[0] - 1);
-	return ((addr[addr[0]] & 0xf0) == 0xf0) ? l - 1 : l;
-}
-
-
-static gn_error gnapplet_sms_pdu_encode(unsigned char *buf, int *len, const gn_sms_raw *rawsms)
-{
-	unsigned char *pos, *fpos, first_octet;
-	int *pdu_format;
-	int i, l;
-
-	memset(buf, 0, *len);
-	pos = buf;
-
-	/* smsc address */
-	*pos++ = gnapplet_get_semi(rawsms->message_center);
-	memcpy(pos, rawsms->message_center + 1, rawsms->message_center[0]);
-	pos += rawsms->message_center[0];
-
-	/* first octet */
-	fpos = pos++;
-	first_octet = rawsms->type >> 1;
-	switch (rawsms->type) {
-	case GN_SMS_MT_Deliver: pdu_format = pdu_deliver; break;
-	case GN_SMS_MT_Submit: pdu_format = pdu_submit; break;
-	case GN_SMS_MT_StatusReport: pdu_format = pdu_status_report; break;
-	default: return GN_ERR_FAILED;
-	}
-
-	for (i = 0; pdu_format[i] > 0; i++) {
-		switch (pdu_format[i]) {
-		case 2: /* TP-MMS */
-			if (rawsms->more_messages) first_octet |= 0x04;
-			break;
-		case 3: /* TP-VPF */
-			first_octet |= rawsms->validity_indicator << 3;
-			break;
-		case 4: /* TP-SRI */
-		case 5: /* TP-SRR */
-		case 26:/* TP-SRQ */
-			if (rawsms->report) first_octet |= 0x20;
-			break;
-		case 6: /* TP-MR */
-			*pos++ = rawsms->reference;
-			break;
-		case 7: /* TP-OA */
-		case 8: /* TP-DA */
-		case 14:/* TP-RA */
-			l = gnapplet_get_addrlen(rawsms->remote_number) + 1;
-			assert(l > 0 && l <= sizeof(rawsms->remote_number));
-			memcpy(pos, rawsms->remote_number, l);
-			pos += l;
-			break;
-		case 9: /* TP-PID */
-			*pos++ = rawsms->pid;
-			break;
-		case 10:/* TP-DCS */
-			*pos++ = rawsms->dcs;
-			break;
-		case 11:/* TP-SCTS */
-			memcpy(pos, rawsms->smsc_time, 7);
-			pos += 7;
-			break;
-		case 12:/* TP-VP */
-			switch (rawsms->validity_indicator) {
-			case GN_SMS_VP_None: l = 0; break;
-			case GN_SMS_VP_RelativeFormat: l = 1; break;
-			default: l = 7; break;
-			}
-			memcpy(pos, rawsms->validity, l);
-			pos += l;
-			break;
-		case 13:/* TP-DT */
-			memcpy(pos, rawsms->time, 7);
-			pos += 7;
-			break;
-		case 15:/* TP-ST */
-		case 22:/* TP-FCS */
-			*pos++ = rawsms->report_status;
-			break;
-		case 16:/* TP-UDL */
-		case 20:/* TP-CDL */
-			*pos++ = rawsms->length;
-			break;
-		case 17:/* TP-RP */
-			if (rawsms->reply_via_same_smsc) first_octet |= 0x80;
-			break;
-		case 18:/* TP-MN */
-			*pos++ = rawsms->number;
-			break;
-		case 19:/* TP-CT */
-			pos++; /* unused */
-			break;
-		case 21:/* TP-CD */
-		case 24:/* TP-UD */
-			assert(rawsms->user_data_length <= *len - (pos - buf));
-			memcpy(pos, rawsms->user_data, rawsms->user_data_length);
-			pos += rawsms->user_data_length;
-			break;
-		case 23:/* TP-UDHI */
-			if (rawsms->udh_indicator) first_octet |= 0x40;
-			break;
-		case 25:/* TP-RD */
-			if (rawsms->reject_duplicates) first_octet |= 0x04;
-			break;
-		case 27:/* TP-PI */
-			pos++; /* unused */
-			break;
-		}
-	}
-	*fpos = first_octet;
-	*len = pos - buf;
-
-	return GN_ERR_NONE;
-}
-
 
 static gn_error gnapplet_functions(gn_operation op, gn_data *data, struct gn_statemachine *state)
 {
@@ -886,7 +751,7 @@ static gn_error gnapplet_sms_message_write(gn_data *data, struct gn_statemachine
 	if (!data->raw_sms) return GN_ERR_INTERNALERROR;
 
 	n = sizeof(buf);
-	if ((error = gnapplet_sms_pdu_encode(buf, &n, data->raw_sms)) != GN_ERR_NONE)
+	if ((error = gn_sms_raw2pdu(buf, &n, data->raw_sms, 0)) != GN_ERR_NONE)
 		return error;
 	//if ((error = gnapplet_sms_validate(data, state)) != GN_ERR_NONE) return error;
 	//data->raw_sms->number = data->sms_folder->locations[data->raw_sms->number - 1];
@@ -910,7 +775,7 @@ static gn_error gnapplet_sms_message_send(gn_data *data, struct gn_statemachine 
 	if (!data->raw_sms) return GN_ERR_INTERNALERROR;
 
 	n = sizeof(buf);
-	if ((error = gnapplet_sms_pdu_encode(buf, &n, data->raw_sms)) != GN_ERR_NONE)
+	if ((error = gn_sms_raw2pdu(buf, &n, data->raw_sms, 0)) != GN_ERR_NONE)
 		return error;
 
 	pkt_put_uint16(&pkt, GNAPPLET_MSG_SMS_MESSAGE_SEND_REQ);

--- a/common/phones/gnapplet.c
+++ b/common/phones/gnapplet.c
@@ -165,119 +165,6 @@ static unsigned char gnapplet_get_semi(const unsigned char *addr)
 }
 
 
-static gn_error gnapplet_sms_pdu_decode(gn_sms_raw *rawsms, const unsigned char *buf, int len)
-{
-	const unsigned char *pos;
-	unsigned char first_octet;
-	int *pdu_format;
-	int i, l;
-
-	pos = buf;
-
-	/* smsc address */
-	l = gnapplet_get_addrlen(pos);
-	assert(l >= 0 && l < sizeof(rawsms->message_center));
-	rawsms->message_center[0] = l;
-	memcpy(rawsms->message_center + 1, pos + 1, l);
-	pos += l + 1;
-
-	/* first octet */
-	first_octet = *pos++;
-	rawsms->type = (first_octet & 0x03) << 1;
-	switch (rawsms->type) {
-	case GN_SMS_MT_Deliver: pdu_format = pdu_deliver; break;
-	case GN_SMS_MT_Submit: pdu_format = pdu_submit; break;
-	case GN_SMS_MT_StatusReport: pdu_format = pdu_status_report; break;
-	default: return GN_ERR_FAILED;
-	}
-
-	for (i = 0; pdu_format[i] > 0; i++) {
-		switch (pdu_format[i]) {
-		case 2: /* TP-MMS */
-			rawsms->more_messages = ((first_octet & 0x04) != 0);
-			break;
-		case 3: /* TP-VPF */
-			rawsms->validity_indicator = (first_octet & 0x18) >> 3;
-			break;
-		case 4: /* TP-SRI */
-		case 5: /* TP-SRR */
-		case 26:/* TP-SRQ */
-			rawsms->report = ((first_octet & 0x20) != 0);
-			break;
-		case 6: /* TP-MR */
-			rawsms->reference = *pos++;
-			break;
-		case 7: /* TP-OA */
-		case 8: /* TP-DA */
-		case 14:/* TP-RA */
-			l = gnapplet_get_addrlen(pos) + 1;
-			assert(l > 0 && l <= sizeof(rawsms->remote_number));
-			memcpy(rawsms->remote_number, pos, l);
-			pos += l;
-			break;
-		case 9: /* TP-PID */
-			rawsms->pid = *pos++;
-			break;
-		case 10:/* TP-DCS */
-			rawsms->dcs = *pos++;
-			break;
-		case 11:/* TP-SCTS */
-			memcpy(rawsms->smsc_time, pos, 7);
-			pos += 7;
-			break;
-		case 12:/* TP-VP */
-			switch (rawsms->validity_indicator) {
-			case GN_SMS_VP_None: l = 0; break;
-			case GN_SMS_VP_RelativeFormat: l = 1; break;
-			default: l = 7; break;
-			}
-			memcpy(rawsms->validity, pos, l);
-			pos += l;
-			break;
-		case 13:/* TP-DT */
-			memcpy(rawsms->time, pos, 7);
-			pos += 7;
-			break;
-		case 15:/* TP-ST */
-		case 22:/* TP-FCS */
-			rawsms->report_status = *pos++;
-			break;
-		case 16:/* TP-UDL */
-		case 20:/* TP-CDL */
-			rawsms->length = *pos++;
-			break;
-		case 17:/* TP-RP */
-			rawsms->reply_via_same_smsc = ((first_octet & 0x80) != 0);
-			break;
-		case 18:/* TP-MN */
-			rawsms->number = *pos++;
-			break;
-		case 19:/* TP-CT */
-			pos++; /* unused */
-			break;
-		case 21:/* TP-CD */
-		case 24:/* TP-UD */
-			rawsms->user_data_length = len - (pos - buf);
-			assert(rawsms->user_data_length >= 0 && rawsms->user_data_length < sizeof(rawsms->user_data));
-			memcpy(rawsms->user_data, pos, rawsms->user_data_length);
-			pos += rawsms->user_data_length;
-			break;
-		case 23:/* TP-UDHI */
-			rawsms->udh_indicator = (first_octet & 0x40);
-			break;
-		case 25:/* TP-RD */
-			rawsms->reject_duplicates = ((first_octet & 0x04) != 0);
-			break;
-		case 27:/* TP-PI */
-			pos++; /* unused */
-			break;
-		}
-	}
-
-	return GN_ERR_NONE;
-}
-
-
 static gn_error gnapplet_sms_pdu_encode(unsigned char *buf, int *len, const gn_sms_raw *rawsms)
 {
 	unsigned char *pos, *fpos, first_octet;
@@ -1189,7 +1076,8 @@ static gn_error gnapplet_incoming_sms(int messagetype, unsigned char *message, i
 		i = pkt_get_bytes(buf, sizeof(buf), &pkt);
 		//rawsms->memory_type = pkt_get_uint16(&pkt);
 		rawsms->status = pkt_get_uint8(&pkt);
-		if ((error = gnapplet_sms_pdu_decode(rawsms, buf, i)) != GN_ERR_NONE)
+		/* the applet sends plain GSM 03.40 PDUs (via the Symbian SMS stack) */
+		if ((error = gn_sms_pdu2raw(rawsms, buf, i, GN_SMS_PDU_DEFAULT)) != GN_ERR_NONE)
 			return error;
 		break;
 

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -4507,6 +4507,14 @@ static gn_error NK6510_IncomingNetwork(int messagetype, unsigned char *message, 
 	case 0x26:
 		dprintf("Op Logo Set OK\n");
 		break;
+	case 0xb6:
+		/* Series 40 6th edition, RF level at message[4] */
+		dprintf("Network/cell info broadcast (RF level %d)\n", message[4]);
+		if (data->rf_level) {
+			*(data->rf_unit) = GN_RF_Percentage;
+			*(data->rf_level) = message[4];
+		}
+		break;
 	default:
 		dprintf("%s: Unknown subtype 0x%02x\n", __FUNCTION__, message[3]);
 		return GN_ERR_UNHANDLEDFRAME;

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -4785,6 +4785,23 @@ static gn_error NK6510_IncomingNetwork(int messagetype, unsigned char *message, 
 			*(data->rf_level) = message[4];
 		}
 		break;
+	/*
+	 * Series 40 6th edition streams unsolicited network-state broadcasts on
+	 * this channel once it is subscribed (cell reselection/registration and
+	 * operator-name updates). gnokii does not consume them; skip them quietly
+	 * instead of logging each as an unhandled frame.
+	 */
+	case 0x35:
+	case 0x42:
+	case 0x49:
+	case 0xb4:
+	case 0xb7:
+	case 0xb8:
+	case 0xb9:
+	case 0xba:
+	case 0xe2:
+		dprintf("Network-state broadcast (subtype 0x%02x), skipping\n", message[3]);
+		return GN_ERR_UNSOLICITED;
 	default:
 		dprintf("%s: Unknown subtype 0x%02x\n", __FUNCTION__, message[3]);
 		return GN_ERR_UNHANDLEDFRAME;

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -1903,6 +1903,75 @@ err:
 			free(data->sms);
 		break;
 	}
+	case 0x43: { /* Series 40 6th ed. (C2-00/RM-704): pushed incoming SMS-DELIVER */
+		/*
+		 * The message arrives in length-prefixed sub-blocks
+		 * (<type> <len16 BE> <data>): 0x82 carries the SMSC, 0x1c the message.
+		 * Past a 2-byte inner length the 0x1c block is a standard SMS-DELIVER
+		 * TPDU (first octet, TP-OA, PID, DCS, SCTS, UDL, UD). Reassemble the
+		 * [SMSC][TPDU] PDU, decode it with the shared decoder and hand the
+		 * result to the on_sms callback (used by --smsreader).
+		 */
+		unsigned char pdu[512], *smsc = NULL, *tpdu = NULL;
+		int smsclen = 0, tpdulen = 0, freerawsms = 0, freesms = 0;
+		unsigned int o;
+
+		if (!data->raw_sms) { freerawsms = 1; data->raw_sms = calloc(1, sizeof(gn_sms_raw)); }
+		if (!data->sms)     { freesms = 1;    data->sms = calloc(1, sizeof(gn_sms)); }
+		if (!data->raw_sms || !data->sms) { e = GN_ERR_INTERNALERROR; goto err43; }
+
+		o = 7;
+		while (o + 5 <= (unsigned) length) {
+			unsigned int blen = (message[o + 1] << 8) | message[o + 2];
+
+			if (blen < 6)
+				break;
+			if (o + blen > (unsigned) length)	/* tolerate a short final block */
+				blen = length - o;
+			if (message[o] == 0x82) {		/* SMSC (octet-length-prefixed) */
+				smsc = message + o + 5;
+				smsclen = smsc[0] + 1;
+			} else if (message[o] == 0x1c) {	/* the delivered message TPDU */
+				tpdu = message + o + 5;
+				tpdulen = blen - 5;
+			}
+			o += blen;
+		}
+
+		/* Trim the 0x1c block's trailing padding to the exact TPDU length. */
+		if (tpdu && tpdulen >= 13) {
+			unsigned int p = 3 + (tpdu[1] + 1) / 2;		/* index past TP-OA */
+
+			if ((int) (p + 10) <= tpdulen) {
+				unsigned int udl = tpdu[p + 9];
+				unsigned int ud = ((tpdu[p + 1] & 0x0c) == 0) ? (udl * 7 + 7) / 8 : udl;
+
+				if ((int) (p + 10 + ud) <= tpdulen)
+					tpdulen = p + 10 + ud;
+			}
+		}
+
+		if (!smsc || !tpdu || smsclen < 2 || tpdulen < 1 ||
+		    smsclen + tpdulen > (int) sizeof(pdu)) {
+			dprintf("Incoming SMS (0x43): SMSC/TPDU sub-blocks not found\n");
+			e = GN_ERR_FAILED;
+			goto err43;
+		}
+
+		memcpy(pdu, smsc, smsclen);
+		memcpy(pdu + smsclen, tpdu, tpdulen);
+
+		memset(data->raw_sms, 0, sizeof(gn_sms_raw));
+		e = gn_sms_pdu2raw(data->raw_sms, pdu, smsclen + tpdulen, GN_SMS_PDU_DEFAULT);
+		if (e == GN_ERR_NONE)
+			e = gn_sms_parse(data);
+		if ((e == GN_ERR_NONE) && DRVINSTANCE(state)->on_sms)
+			e = DRVINSTANCE(state)->on_sms(data->sms, state, DRVINSTANCE(state)->sms_callback_data);
+err43:
+		if (freerawsms && data->raw_sms) { free(data->raw_sms); data->raw_sms = NULL; }
+		if (freesms && data->sms)         { free(data->sms); data->sms = NULL; }
+		break;
+	}
 	case NK6510_SUBSMS_SMSC_RCV: /* 0x15 */
 		switch (message[4]) {
 		case 0x00:

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -1831,7 +1831,7 @@ static gn_error NK6510_SaveSMS(gn_data *data, struct gn_statemachine *state)
 			  "It may have to be sent to Nokia Service if something fails!\n"
 			  "Do you really want to continue? "));
 	fprintf(stdout, _("(yes/no) "));
-	gn_line_get(stdin, ans, 4);
+	gn_line_get(stdin, ans, sizeof(ans));
 	if (strcmp(ans, _("yes"))) return GN_ERR_USERCANCELED;
 
 	if (sm_message_send(len, NK6510_MSG_FOLDER, req, state)) return GN_ERR_NOTREADY;

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -2177,6 +2177,9 @@ static gn_error NK6510_GetSMSCenter(gn_data *data, struct gn_statemachine *state
 {
 	unsigned char req[] = {FBUS_FRAME_HEADER, NK6510_SUBSMS_GET_SMSC, 0x01, 0x00};
 
+	if (DRVINSTANCE(state)->pm->flags & PM_SMSFILE)
+		return GN_ERR_NOTSUPPORTED;
+
 	req[4] = data->message_center->id;
 	SEND_MESSAGE_BLOCK(NK6510_MSG_SMS, 6);
 }

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -1975,6 +1975,11 @@ err:
 		break;
 
 	case NK6510_SUBSMS_SMS_SEND_STATUS: /* 0x03 */
+		if (length <= 10) {
+			dprintf("SMS sending failed (submit rejected, idx 0x%02x)\n", message[6]);
+			e = GN_ERR_FAILED;
+			break;
+		}
 		switch (message[8]) {
 		case NK6510_SUBSMS_SMS_SEND_OK: /* 0x00 */
 			dprintf("SMS sent (reference: %d)\n", message[10]);

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -2044,6 +2044,89 @@ static gn_error NK6510_GetSMSCenter(gn_data *data, struct gn_statemachine *state
 	SEND_MESSAGE_BLOCK(NK6510_MSG_SMS, 6);
 }
 
+/*
+ * Series 40 6th edition messaging (e.g. C2-00/RM-704).
+ *
+ * These phones reject the native FBUS SMS submit (0x02). Instead PC Suite drops
+ * the SMS-SUBMIT TPDU into the message store's "exchange" pseudo-folder and then
+ * issues a "send" command, which makes the phone transmit it.
+ * Do the same here, write the TPDU to C:\predefmessages\exchange\<handle>
+ * with NK6510_PutFile, then trigger the send.
+ *
+ * NB the exchange write only *queues* the message in the Outbox; without the
+ * trigger it sits there until the phone reboots.
+ */
+
+/*
+ * Ask the phone to transmit pending/queued messages. This is the PC-Suite
+ * messaging "send" command (phonet message type 0xaa, sub-command 0x18). It is
+ * independent of how the message was queued, so it is shared by every send
+ * path. The phone acknowledges with sub-command 0x19.
+ */
+static gn_error NK6510_SendMessageTrigger(struct gn_statemachine *state)
+{
+	static const unsigned char trigger[] = { 0x00, 0x01, 0x01, 0x18, 0x00, 0x00 };
+
+	if (sm_message_send(sizeof(trigger), 0xaa, (void *) trigger, state))
+		return GN_ERR_NOTREADY;
+	gn_sm_loop(10, state);
+	return GN_ERR_NONE;
+}
+
+/* Submit an SMS by writing its TPDU to the exchange folder, then triggering. */
+static gn_error NK6510_SendSMS_File(gn_data *data, struct gn_statemachine *state)
+{
+	gn_sms_raw *raw = data->raw_sms;
+	unsigned char tpdu[256];
+	char number[GN_SMS_NUMBER_MAX_LENGTH], handle[96];
+	gn_file file, *saved;
+	gn_error error;
+	int tpdu_len = sizeof(tpdu);
+	unsigned int i, ndigits, off = 0;
+
+	if (!raw)
+		return GN_ERR_INTERNALERROR;
+
+	/* SMS-SUBMIT TPDU without SMSC - the phone supplies its own */
+	error = gn_sms_raw2pdu(tpdu, &tpdu_len, raw, GN_SMS_PDU_NOSMSC);
+	if (error != GN_ERR_NONE)
+		return error;
+
+	/* Destination number as plain digits optionally prefixed with
+	 * international '+' for the file handle */
+	if (raw->remote_number[1] == GN_GSM_NUMBER_International)
+		number[off++] = '+';
+	ndigits = raw->remote_number[0];
+	if (ndigits > sizeof(number) - off - 1)
+		ndigits = sizeof(number) - off - 1;
+	for (i = 0; i < ndigits; i++) {
+		unsigned char b = raw->remote_number[2 + i / 2];
+		number[off + i] = ((i & 1) ? (b >> 4) : (b & 0x0f)) + '0';
+	}
+	number[off + ndigits] = '\0';
+
+	snprintf(handle, sizeof(handle),
+		 "00000002%08x000021000700000001010000%02u%s",
+		 (unsigned) time(NULL), (unsigned) strlen(number), number);
+
+	memset(&file, 0, sizeof(file));
+	snprintf(file.name, sizeof(file.name),
+		 "C:\\predefmessages\\exchange\\%s", handle);
+	file.file = tpdu;
+	file.file_length = tpdu_len;
+
+	saved = data->file;
+	data->file = &file;
+	error = NK6510_PutFile(data, state);
+	data->file = saved;
+	if (error != GN_ERR_NONE) {
+		dprintf("SMS exchange write failed: %s\n", gn_error_print(error));
+		return error;
+	}
+	dprintf("SMS queued; triggering send\n");
+	return NK6510_SendMessageTrigger(state);
+}
+
 /**
  * NK6510_SendSMS - low level SMS sending function for 6310/6510 phones
  * @data: gsm data
@@ -2054,13 +2137,15 @@ static gn_error NK6510_GetSMSCenter(gn_data *data, struct gn_statemachine *state
  * soon.
  * 10.07.2002: Almost all frames should be known know :-) (Markus)
  */
-
 static gn_error NK6510_SendSMS(gn_data *data, struct gn_statemachine *state)
 {
 	unsigned char req[256] = {FBUS_FRAME_HEADER, 0x02,
 				  0x00, 0x00, 0x00, 0x55, 0x55}; /* What's this? */
 	gn_error error;
 	unsigned int pos;
+
+	if (DRVINSTANCE(state)->pm->flags & PM_SMSFILE)
+		return NK6510_SendSMS_File(data, state);
 
 	memset(req + 9, 0, 244);
 	pos = sms_encode(data, state, req + 9);
@@ -2070,6 +2155,7 @@ static gn_error NK6510_SendSMS(gn_data *data, struct gn_statemachine *state)
 	do {
 		error = sm_block_no_retry_timeout(NK6510_MSG_SMS, state->config.smsc_timeout, data, state);
 	} while (!state->config.smsc_timeout && error == GN_ERR_TIMEOUT);
+
 	return error;
 }
 

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -330,6 +330,8 @@ static gn_error NK6510_IncomingSecurity(int messagetype, unsigned char *message,
 
 static gn_error NK6510_IncomingPassthrough(int messagetype, unsigned char *message, int length, gn_data *data, struct gn_statemachine *state);
 
+static gn_error NK6510_IncomingMsgStatus(int messagetype, unsigned char *message, int length, gn_data *data, struct gn_statemachine *state);
+
 static int sms_encode(gn_data *data, struct gn_statemachine *state, unsigned char *req);
 static int get_memory_type(gn_memory_type memory_type);
 static gn_memory_type get_gn_memory_type_sms(int memory_type);
@@ -359,6 +361,7 @@ static gn_incoming_function_type nk6510_incoming_functions[] = {
 	{ NK6510_MSG_SOUND,	NK6510_IncomingSound },
 	{ NK6510_MSG_RADIO,	NK6510_IncomingRadio },
 	{ NK6510_MSG_FILE,	NK6510_IncomingFile },
+	{ NK6510_MSG_MSGSTATUS,	NK6510_IncomingMsgStatus },
 	{ 0, NULL }
 };
 
@@ -2021,6 +2024,13 @@ err:
 			dprintf("Warning: no data->raw_sms allocated and got response for send_sms()\n");
 		e = GN_ERR_ASYNC;
 		break;
+
+	case 0x48: /* Series 40 exchange path: async send report */
+	case 0x4b: /* Series 40 exchange path: async message info */
+		dprintf("SMS async send notification (subtype 0x%02x), skipping\n", message[3]);
+		e = GN_ERR_UNSOLICITED;
+		break;
+
 	case NK6510_SUBSMS_SMS_RCVD: /* 0x10 */
 	case NK6510_SUBSMS_CELLBRD_OK: /* 0x21 */
 	case NK6510_SUBSMS_READ_CELLBRD: /* 0x23 */
@@ -2033,6 +2043,64 @@ err:
 		dprintf("%s: Unknown subtype 0x%02x\n", __FUNCTION__, message[3]);
 		return GN_ERR_UNHANDLEDFRAME;
 	}
+	return e;
+}
+
+/*
+ * Decode per-message send-progress status frames (subtype 0x60). These are
+ * pushed unsolicited once the 0xaa channel is subscribed, so they cannot be
+ * waited on with sm_block; instead, when one reports 0x05 for the handle
+ * NK6510_SendSMS_File is watching (DRVINSTANCE->sms_send_handle), we set
+ * the sms_send_done flag it polls. These frames stay GN_ERR_UNSOLICITED.
+ */
+static gn_error NK6510_IncomingMsgStatus(int messagetype, unsigned char *message, int length, gn_data *data, struct gn_statemachine *state)
+{
+	char hex[3 * 64 + 1];
+	gn_error e = GN_ERR_UNSOLICITED;
+	int i, n = 0;
+
+	if (length < 4)
+		return GN_ERR_UNSOLICITED;
+
+	switch (message[3]) {
+	case 0x60: /* per-message send-progress status */
+		if (length >= 42) {
+			unsigned long handle = ((unsigned long) message[38] << 24) |
+					       (message[39] << 16) | (message[40] << 8) | message[41];
+			dprintf("MsgStatus: handle=%08lx slot=0x%02x state[5]=0x%02x state[18]=0x%02x (len %d)\n",
+				handle, message[37], message[5], message[18], length);
+			/* state[5]==0x05 ("stored/sent") on the handle we are watching
+			   means the message was submitted to the network. */
+			if (DRVINSTANCE(state)->sms_send_handle &&
+			    DRVINSTANCE(state)->sms_send_handle == handle && message[5] == 0x05) {
+				dprintf("MsgStatus: message %08lx sent to network\n", handle);
+				DRVINSTANCE(state)->sms_send_done = 1;
+			}
+		} else {
+			dprintf("MsgStatus: short 0x60 status frame (len %d)\n", length);
+		}
+		break;
+	case 0x18: /* send trigger (our own request, echoed) */
+		dprintf("MsgStatus: send trigger (0x18)\n");
+		break;
+	case 0x19: /* ack of the send trigger */
+		if (length >= 6 && (message[4] || message[5])) {
+			dprintf("MsgStatus: send trigger rejected (status 0x%02x%02x)\n", message[4], message[5]);
+			e = GN_ERR_FAILED;
+		} else {
+			dprintf("MsgStatus: send trigger accepted (0x19)\n");
+			e = GN_ERR_NONE;
+		}
+		break;
+	default:
+		dprintf("MsgStatus: subtype 0x%02x (len %d)\n", message[3], length);
+		break;
+	}
+
+	for (i = 0; i < length && i < 64; i++)
+		n += snprintf(hex + n, sizeof(hex) - n, "%02x ", message[i]);
+	dprintf("MsgStatus raw: %s\n", hex);
+
 	return e;
 }
 
@@ -2063,14 +2131,33 @@ static gn_error NK6510_GetSMSCenter(gn_data *data, struct gn_statemachine *state
  * independent of how the message was queued, so it is shared by every send
  * path. The phone acknowledges with sub-command 0x19.
  */
-static gn_error NK6510_SendMessageTrigger(struct gn_statemachine *state)
+static gn_error NK6510_SendMessageTrigger(gn_data *data, struct gn_statemachine *state)
 {
 	static const unsigned char trigger[] = { 0x00, 0x01, 0x01, 0x18, 0x00, 0x00 };
 
-	if (sm_message_send(sizeof(trigger), 0xaa, (void *) trigger, state))
+	if (sm_message_send(sizeof(trigger), NK6510_MSG_MSGSTATUS, (void *) trigger, state))
 		return GN_ERR_NOTREADY;
-	gn_sm_loop(10, state);
-	return GN_ERR_NONE;
+	/* Wait for the 0x19 ack (NK6510_IncomingMsgStatus resolves it). */
+	return sm_block_no_retry_timeout(NK6510_MSG_MSGSTATUS, 10, data, state);
+}
+
+/*
+ * Subscribe to the messaging-status channel (0xaa) so the phone pushes the
+ * async 0x60 send-progress notifications - a bare session gets only the trigger
+ * ack and no status at all.
+ */
+static gn_error NK6510_SubscribeMsgStatus(struct gn_statemachine *state)
+{
+	unsigned char req[] = {FBUS_FRAME_HEADER, 0x10, 0x07,
+			       NK6510_MSG_COMMSTATUS, NK6510_MSG_SMS,
+			       NK6510_MSG_NETSTATUS, NK6510_MSG_FOLDER,
+			       NK6510_MSG_RESET, NK6510_MSG_BATTERY,
+			       NK6510_MSG_MSGSTATUS};
+
+	dprintf("Subscribing to the messaging-status channel (0xaa)\n");
+	if (sm_message_send(sizeof(req), NK6510_MSG_SUBSCRIBE, req, state))
+		return GN_ERR_NOTREADY;
+	return sm_block_ack(state);
 }
 
 /* Submit an SMS by writing its TPDU to the exchange folder, then triggering. */
@@ -2083,6 +2170,7 @@ static gn_error NK6510_SendSMS_File(gn_data *data, struct gn_statemachine *state
 	gn_error error;
 	int tpdu_len = sizeof(tpdu);
 	unsigned int i, ndigits, off = 0;
+	unsigned msgid = (unsigned) time(NULL);
 
 	if (!raw)
 		return GN_ERR_INTERNALERROR;
@@ -2107,7 +2195,7 @@ static gn_error NK6510_SendSMS_File(gn_data *data, struct gn_statemachine *state
 
 	snprintf(handle, sizeof(handle),
 		 "00000002%08x000021000700000001010000%02u%s",
-		 (unsigned) time(NULL), (unsigned) strlen(number), number);
+		 msgid, (unsigned) strlen(number), number);
 
 	memset(&file, 0, sizeof(file));
 	snprintf(file.name, sizeof(file.name),
@@ -2123,8 +2211,35 @@ static gn_error NK6510_SendSMS_File(gn_data *data, struct gn_statemachine *state
 		dprintf("SMS exchange write failed: %s\n", gn_error_print(error));
 		return error;
 	}
-	dprintf("SMS queued; triggering send\n");
-	return NK6510_SendMessageTrigger(state);
+	dprintf("SMS queued (handle msgid=%08x); sudscribing and triggering send\n", msgid);
+
+	/* Subscribe so the phone pushes the 0x60 send-progress status */
+	if (NK6510_SubscribeMsgStatus(state) != GN_ERR_NONE)
+		dprintf("SMS status subscription failed\n");
+
+	error = NK6510_SendMessageTrigger(data, state);
+	if (error != GN_ERR_NONE)
+		return error;
+
+	/*
+	 * The 0x60 status is pushed unsolicited, so it cannot be waited on
+	 * with sm_block (which needs a preceding request). Pump the link
+	 * instead and let NK6510_IncomingMsgStatus flag when our handle
+	 * reaches "sent" (0x05). Reaching 0x05 means submitted to the
+	 * network. If it does not arrive in time, report ASYNC (queued).
+	 */
+	DRVINSTANCE(state)->sms_send_handle = msgid;
+	DRVINSTANCE(state)->sms_send_done = 0;
+	for (i = 0; i < 150 && !DRVINSTANCE(state)->sms_send_done; i++)
+		gn_sm_loop(1, state);
+	DRVINSTANCE(state)->sms_send_handle = 0;
+
+	if (DRVINSTANCE(state)->sms_send_done) {
+		dprintf("SMS sent to network\n");
+		return GN_ERR_NONE;
+	}
+	dprintf("SMS queued but send not confirmed within timeout\n");
+	return GN_ERR_ASYNC;
 }
 
 /**

--- a/common/phones/nk6510.c
+++ b/common/phones/nk6510.c
@@ -4267,6 +4267,7 @@ static gn_error NK6510_DeleteCalTodo_S40_30(gn_data *data, struct gn_statemachin
 				0x00, 0x00, 0x00,
 				0x00, 0x00}; /*location */
 	gn_calnote_list list;
+	gn_error error = GN_ERR_NONE;
 	bool own_list = true;
 
 	if (type != 0x00 && type != 0x01 && type != 0x02)
@@ -4282,19 +4283,26 @@ static gn_error NK6510_DeleteCalTodo_S40_30(gn_data *data, struct gn_statemachin
 	}
 
 	if (data->calnote_list->number == 0)
-		NK6510_GetCalendarNotesInfo(data, state, type);
+		error = NK6510_GetCalendarNotesInfo(data, state, type);
 
-	if (data->calnote->location < data->calnote_list->number + 1 &&
-	    data->calnote->location > 0) {
-		req[8] = data->calnote_list->location[data->calnote->location - 1] >> 8;
-		req[9] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
-	} else {
-		return GN_ERR_INVALIDLOCATION;
+	if (error == GN_ERR_NONE) {
+		if (data->calnote->location < data->calnote_list->number + 1 &&
+		    data->calnote->location > 0) {
+			req[8] = data->calnote_list->location[data->calnote->location - 1] >> 8;
+			req[9] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
+		} else {
+			error = GN_ERR_INVALIDLOCATION;
+		}
 	}
 
 	if (own_list)
 		data->calnote_list = NULL;
+
 	map_del(&location_map, "calendar");
+
+	if (error != GN_ERR_NONE)
+		return error;
+
 	SEND_MESSAGE_BLOCK(NK6510_MSG_CALENDAR, 10);
 }
 
@@ -4305,7 +4313,7 @@ static gn_error NK6510_DeleteCalendarNote_S40_30(gn_data *data, struct gn_statem
 
 static gn_error NK6510_DeleteCalendarNote(gn_data *data, struct gn_statemachine *state)
 {
-	gn_error error;
+	gn_error error = GN_ERR_NONE;
 	unsigned char req[] = { FBUS_FRAME_HEADER,
 				0x0b,      /* delete calendar note */
 				0x00, 0x00}; /*location */
@@ -4323,18 +4331,23 @@ static gn_error NK6510_DeleteCalendarNote(gn_data *data, struct gn_statemachine 
 	}
 
 	if (data->calnote_list->number == 0)
-		NK6510_GetCalendarNotesInfo(data, state, 0x00);
+		error = NK6510_GetCalendarNotesInfo(data, state, 0x00);
 
-	if (data->calnote->location < data->calnote_list->number + 1 &&
-	    data->calnote->location > 0) {
-		req[4] = data->calnote_list->location[data->calnote->location - 1] >> 8;
-		req[5] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
-	} else {
-		return GN_ERR_INVALIDLOCATION;
+	if (error == GN_ERR_NONE) {
+		if (data->calnote->location < data->calnote_list->number + 1 &&
+		    data->calnote->location > 0) {
+			req[4] = data->calnote_list->location[data->calnote->location - 1] >> 8;
+			req[5] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
+		} else {
+			error = GN_ERR_INVALIDLOCATION;
+		}
 	}
 
 	if (own_list)
 		data->calnote_list = NULL;
+
+	if (error != GN_ERR_NONE)
+		return error;
 
 	if (sm_message_send(8, NK6510_MSG_CALENDAR, req, state))
 		return GN_ERR_NOTREADY;

--- a/common/phones/nk7110.c
+++ b/common/phones/nk7110.c
@@ -1969,11 +1969,12 @@ static gn_error NK7110_GetCalendarNote(gn_data *data, struct gn_statemachine *st
 
 static gn_error NK7110_DeleteCalendarNote(gn_data *data, struct gn_statemachine *state)
 {
+	gn_calnote_list list;
+	gn_error error = GN_ERR_NONE;
+	bool own_list = true;
 	unsigned char req[] = { FBUS_FRAME_HEADER,
 				0x0b,      /* delete calendar note */
 				0x00, 0x00}; /*location */
-	gn_calnote_list list;
-	bool own_list = true;
 
 	if (data->calnote_list)
 		own_list = false;
@@ -1983,17 +1984,23 @@ static gn_error NK7110_DeleteCalendarNote(gn_data *data, struct gn_statemachine 
 	}
 
 	if (data->calnote_list->number == 0)
-		NK7110_GetCalendarNotesInfo(data, state);
+		error = NK7110_GetCalendarNotesInfo(data, state);
 
-	if (data->calnote->location < data->calnote_list->number + 1 &&
-	    data->calnote->location > 0) {
-		req[4] = data->calnote_list->location[data->calnote->location - 1] >> 8;
-		req[5] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
-	} else {
-		return GN_ERR_INVALIDLOCATION;
+	if (error == GN_ERR_NONE) {
+		if (data->calnote->location < data->calnote_list->number + 1 &&
+		    data->calnote->location > 0) {
+			req[4] = data->calnote_list->location[data->calnote->location - 1] >> 8;
+			req[5] = data->calnote_list->location[data->calnote->location - 1] & 0xff;
+		} else {
+			error = GN_ERR_INVALIDLOCATION;
+		}
 	}
+	if (own_list)
+		data->calnote_list = NULL;
 
-	if (own_list) data->calnote_list = NULL;
+	if (error != GN_ERR_NONE)
+		return error;
+
 	SEND_MESSAGE_BLOCK(NK7110_MSG_CALENDAR, 6);
 }
 

--- a/common/phones/nokia.c
+++ b/common/phones/nokia.c
@@ -479,10 +479,10 @@ gn_error pnok_security_incoming(int messagetype, unsigned char *message, int len
 
 		bin2hex(tmp, message + 9, 12);
 
-		strncpy(data->locks_info[0].data, tmp, 5);
-		strncpy(data->locks_info[1].data, tmp + 16, 4);
-		strncpy(data->locks_info[2].data, tmp + 20, 4);
-		strncpy(data->locks_info[3].data, tmp + 5, 10);
+		memcpy(data->locks_info[0].data, tmp, 5);
+		memcpy(data->locks_info[1].data, tmp + 16, 4);
+		memcpy(data->locks_info[2].data, tmp + 20, 4);
+		memcpy(data->locks_info[3].data, tmp + 5, 10);
 
 		data->locks_info[0].counter = message[21];
 		data->locks_info[1].counter = message[22];

--- a/common/vcard.c
+++ b/common/vcard.c
@@ -339,7 +339,7 @@ GNOKII_API int gn_vcard2phonebook(FILE *f, gn_phonebook_entry *entry)
 	memset(&str, 0, sizeof(str));
 
 	while (1) {
-		if (!fgets(buf, 1024, f))
+		if (!fgets(buf, sizeof(buf), f))
 			return -1;
 		if (BEGINS("BEGIN:VCARD"))
 			break;
@@ -347,7 +347,7 @@ GNOKII_API int gn_vcard2phonebook(FILE *f, gn_phonebook_entry *entry)
 	str_append_printf(&str, buf);
 
 	retval = -1;
-	while (fgets(buf, 1024, f)) {
+	while (fgets(buf, sizeof(buf), f)) {
 		str_append_printf(&str, buf);
 		if (BEGINS("END:VCARD")) {
 			retval = gn_vcardstr2phonebook(str.str, entry);

--- a/gnokii/gnokii-file.c
+++ b/gnokii/gnokii-file.c
@@ -168,7 +168,7 @@ gn_error getfileid(char *filename, gn_data *data, struct gn_statemachine *state)
 	gn_error error;
 
 	memset(&fi, 0, sizeof(fi));
-	snprintf(fi.name, 512, "%s", filename);
+	snprintf(fi.name, sizeof(fi.name), "%s", filename);
 
 	gn_data_clear(data);
 	data->file = &fi;
@@ -188,7 +188,7 @@ gn_error deletefile(char *filename, gn_data *data, struct gn_statemachine *state
 	gn_error error;
 
 	memset(&fi, 0, sizeof(fi));
-	snprintf(fi.name, 512, "%s", filename);
+	snprintf(fi.name, sizeof(fi.name), "%s", filename);
 
 	gn_data_clear(data);
 	data->file = &fi;
@@ -238,9 +238,9 @@ gn_error getfile(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 	if (argc < optind)
 		return getfile_usage(stderr, -1);
 
-	memset(filename2, 0, 512);
+	memset(filename2, 0, sizeof(filename2));
 	memset(&fi, 0, sizeof(fi));
-	snprintf(fi.name, 512, "%s", optarg);
+	snprintf(fi.name, sizeof(fi.name), "%s", optarg);
 
 	gn_data_clear(data);
 	data->file = &fi;
@@ -258,7 +258,7 @@ gn_error getfile(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 			else
 				snprintf(filename2, sizeof(filename2), "default.dat");
 			fprintf(stdout, _("Got file %s.  Save to [%s]: "), optarg, filename2);
-			gn_line_get(stdin, filename2, 512);
+			gn_line_get(stdin, filename2, sizeof(filename2));
 			if (filename2[0] == 0) {
 				if (strrchr(optarg, '/'))
 					snprintf(filename2, sizeof(filename2), "%s", strrchr(optarg, '/') + 1);
@@ -303,7 +303,7 @@ gn_error getfilebyid(int argc, char *argv[], gn_data *data, struct gn_statemachi
 	if (argc < optind)
 		return getfilebyid_usage(stderr, -1);
 
-	memset(filename2, 0, 512);
+	memset(filename2, 0, sizeof(filename2));
 	memset(&fi, 0, sizeof(fi));
 	set_fileid(&fi, optarg);
 
@@ -412,7 +412,7 @@ gn_error putfile(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 		return putfile_usage(stderr, -1);
 
 	memset(&fi, 0, sizeof(fi));
-	snprintf(fi.name, 512, "%s", argv[optind]);
+	snprintf(fi.name, sizeof(fi.name), "%s", argv[optind]);
 
 	gn_data_clear(data);
 	data->file = &fi;

--- a/gnokii/gnokii-logo.c
+++ b/gnokii/gnokii-logo.c
@@ -160,7 +160,7 @@ static gn_error SaveBitmapFileDialog(char *FileName, gn_bmp *bitmap, gn_phone *i
 		confirm = 0;
 		while (!confirm) {
 			fprintf(stderr, _("Saving logo. File \"%s\" exists. (O)verwrite, create (n)ew or (s)kip ? "), FileName);
-			gn_line_get(stdin, ans, 4);
+			gn_line_get(stdin, ans, sizeof(ans));
 			if (!strcmp(ans, _("O")) || !strcmp(ans, _("o"))) confirm = 1;
 			if (!strcmp(ans, _("N")) || !strcmp(ans, _("n"))) confirm = 2;
 			if (!strcmp(ans, _("S")) || !strcmp(ans, _("s"))) return GN_ERR_USERCANCELED;

--- a/gnokii/gnokii-monitor.c
+++ b/gnokii/gnokii-monitor.c
@@ -411,14 +411,6 @@ gn_error displayoutput(gn_data *data, struct gn_statemachine *state)
 		/* Loop here indefinitely - allows you to read texts from phone's
 		   display. The loops ends after pressing the Ctrl+C. */
 		while (!bshutdown) {
-			char buf[105];
-			memset(&buf[0], 0, 102);
-/*			while (read(0, buf, 100) > 0) {
-				fprintf(stderr, _("handling keys (%d).\n"), strlen(buf));
-				if (GSM && GSM->HandleString && GSM->HandleString(buf) != GN_ERR_NONE)
-					fprintf(stderr, _("Key press simulation failed.\n"));
-				memset(buf, 0, 102);
-			}*/
 			gn_sm_loop(1, state);
 			gn_sm_functions(GN_OP_PollDisplay, data, state);
 		}

--- a/gnokii/gnokii-phonebook.c
+++ b/gnokii/gnokii-phonebook.c
@@ -400,7 +400,7 @@ gn_error writephonebook(int argc, char *argv[], gn_data *data, struct gn_statema
 					confirm = -1;
 					while (confirm < 0) {
 						fprintf(stdout, _("Overwrite? (yes/no) "));
-						gn_line_get(stdin, ans, 7);
+						gn_line_get(stdin, ans, sizeof(ans));
 						if (!strcmp(ans, _("yes")))
 							confirm = 1;
 						else if (!strcmp(ans, _("no")))

--- a/gnokii/gnokii-sms.c
+++ b/gnokii/gnokii-sms.c
@@ -396,7 +396,6 @@ gn_error savesms(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 	gn_sms sms;
 	gn_error error = GN_ERR_INTERNALERROR;
 	int i;
-	char tmp[3];
 #if 0
 	int confirm = -1;
 	int interactive = 0;
@@ -501,18 +500,12 @@ gn_error savesms(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 					fprintf(stderr, _("Invalid datetime format: %s (should be YYMMDDHHMISS, all digits)!\n"), optarg);
 					return GN_ERR_WRONGDATAFORMAT;
 				}
-			snprintf(tmp, sizeof(tmp), "%s", optarg);
-			sms.smsc_time.year	= atoi(tmp) + 1900;
-			snprintf(tmp, sizeof(tmp), "%s", optarg+2);
-			sms.smsc_time.month	= atoi(tmp);
-			snprintf(tmp, sizeof(tmp), "%s", optarg+4);
-			sms.smsc_time.day	= atoi(tmp);
-			snprintf(tmp, sizeof(tmp), "%s", optarg+6);
-			sms.smsc_time.hour	= atoi(tmp);
-			snprintf(tmp, sizeof(tmp), "%s", optarg+8);
-			sms.smsc_time.minute	= atoi(tmp);
-			snprintf(tmp, sizeof(tmp), "%s", optarg+10);
-			sms.smsc_time.second	= atoi(tmp);
+			sms.smsc_time.year   = 10 * (optarg[0] - '0') + (optarg[1] - '0') + 1900;
+			sms.smsc_time.month  = 10 * (optarg[2] - '0') + (optarg[3] - '0');
+			sms.smsc_time.day    = 10 * (optarg[4] - '0') + (optarg[5] - '0');
+			sms.smsc_time.hour   = 10 * (optarg[6] - '0') + (optarg[7] - '0');
+			sms.smsc_time.minute = 10 * (optarg[8] - '0') + (optarg[9] - '0');
+			sms.smsc_time.second = 10 * (optarg[10] - '0') + (optarg[11] - '0');
 			if (!gn_timestamp_isvalid(sms.smsc_time)) {
 				fprintf(stderr, _("Invalid datetime: %s.\n"), optarg);
 				return GN_ERR_WRONGDATAFORMAT;

--- a/gnokii/gnokii-sms.c
+++ b/gnokii/gnokii-sms.c
@@ -481,7 +481,7 @@ gn_error savesms(int argc, char *argv[], gn_data *data, struct gn_statemachine *
 			break;
 #endif
 		case 'f': /* Specify the folder where to save the message */
-			snprintf(memory_type, 19, "%s", optarg);
+			snprintf(memory_type, sizeof(memory_type), "%s", optarg);
 			if (gn_str2memory_type(memory_type) == GN_MT_XX) {
 				fprintf(stderr, _("Unknown memory type %s (use ME, SM, IN, OU, ...)!\n"), optarg);
 				fprintf(stderr, _("Run gnokii --showsmsfolderstatus for a list of supported memory types.\n"));
@@ -849,7 +849,7 @@ parsefile:
 						if (mode == GNOKII_APP_MODE_Ask && (stat(filename, &buf) == 0)) {
 							fprintf(stdout, _("File %s exists.\n"), filename);
 							fprintf(stdout, _("Overwrite? (yes/no) "));
-							gn_line_get(stdin, ans, 4);
+							gn_line_get(stdin, ans, sizeof(ans));
 							if (!strcmp(ans, _("yes"))) {
 								error = gn_file_bitmap_save(filename, &bitmap, phone);
 							}
@@ -885,7 +885,7 @@ parsefile:
 				if ((mode != GNOKII_APP_MODE_Cancel) && *filename) {
 					char buf[1024];
 					char *mbox = gn_sms2mbox(&message, "gnokii");
-					snprintf(buf, 1023, "%s", filename);
+					snprintf(buf, sizeof(buf), "%s", filename);
 					mode = writefile(buf, mbox, mode);
 					free(mbox);
 				}

--- a/include/devices/bluetooth.h
+++ b/include/devices/bluetooth.h
@@ -19,8 +19,9 @@
 
 void* bluetooth_open(gn_config *cfg, int with_odd_parity, int with_async);
 void bluetooth_close(void *instance);
-size_t bluetooth_write(void *instance, const __ptr_t bytes, size_t size);
-size_t bluetooth_read(void *instance, __ptr_t bytes, size_t size);
 int bluetooth_select(void *instance, struct timeval *timeout);
+size_t bluetooth_read(void *instance, __ptr_t bytes, size_t size);
+size_t bluetooth_write(void *instance, const __ptr_t bytes, size_t size);
+int bluetooth_getfd(void *instance);
 
 #endif /* _gnokii_bluetooth_h */

--- a/include/devices/irda.h
+++ b/include/devices/irda.h
@@ -17,8 +17,9 @@
 
 void* irda_open(gn_config *cfg, int with_odd_parity, int with_async);
 void irda_close(void *instance);
-size_t irda_write(void *instance, const __ptr_t bytes, size_t size);
-size_t irda_read(void *instance, __ptr_t bytes, size_t size);
 int irda_select(void *instance, struct timeval *timeout);
+size_t irda_read(void *instance, __ptr_t bytes, size_t size);
+size_t irda_write(void *instance, const __ptr_t bytes, size_t size);
+int irda_getfd(void *instance);
 
 #endif /* __gnokii_irda_h_ */

--- a/include/devices/serial.h
+++ b/include/devices/serial.h
@@ -21,15 +21,16 @@ void* serial_init(const char *file, int oflag);
 void* serial_open(gn_config *cfg, int with_odd_parity, int with_async);
 void serial_close(void *instance);
 
-void serial_setdtrrts(void *instance, int dtr, int rts);
-gn_error serial_changespeed(void *instance, int speed);
-
+int serial_select(void *instance, struct timeval *timeout);
 size_t serial_read(void *instance, __ptr_t buf, size_t nbytes);
 size_t serial_write(void *instance, const __ptr_t buf, size_t n);
 
-int serial_select(void *instance, struct timeval *timeout);
+int serial_getfd(void *instance);
 
 gn_error serial_nreceived(void *instance, int *n);
 gn_error serial_flush(void *instance);
+
+gn_error serial_changespeed(void *instance, int speed);
+void serial_setdtrrts(void *instance, int dtr, int rts);
 
 #endif  /* __devices_serial_h */

--- a/include/devices/socketphonet.h
+++ b/include/devices/socketphonet.h
@@ -23,8 +23,9 @@
 
 void* socketphonet_open(gn_config *cfg, int with_odd_parity, int with_async);
 void socketphonet_close(void *instance);
+int socketphonet_select(void *instance, struct timeval *timeout);
 size_t socketphonet_read(void *instance, __ptr_t buf, size_t nbytes);
 size_t socketphonet_write(void *instance, const __ptr_t buf, size_t n);
-int socketphonet_select(void *instance, struct timeval *timeout);
+int socketphonet_getfd(void *instance);
 
 #endif /* _gnokii_devices_linuxphonet_h */

--- a/include/devices/tcp.h
+++ b/include/devices/tcp.h
@@ -19,9 +19,10 @@
 void* tcp_open(gn_config *cfg, int with_odd_parity, int with_async);
 void tcp_close(void *instance);
 
+int tcp_select(void *instance, struct timeval *timeout);
 size_t tcp_read(void *instance, __ptr_t buf, size_t nbytes);
 size_t tcp_write(void *instance, const __ptr_t buf, size_t n);
 
-int tcp_select(void *instance, struct timeval *timeout);
+int tcp_getfd(void *instance);
 
 #endif  /* __devices_tcp_h */

--- a/include/devices/tekram.h
+++ b/include/devices/tekram.h
@@ -26,12 +26,13 @@
 void* tekram_open(gn_config *cfg, int with_odd_parity, int with_async);
 void tekram_close(void *instance);
 
-void tekram_setdtrrts(void *instance, int dtr, int rts);
-void tekram_changespeed(void *instance, int speed);
-
+int tekram_select(void *instance, struct timeval *timeout);
 size_t tekram_read(void *instance, __ptr_t buf, size_t nbytes);
 size_t tekram_write(void *instance, const __ptr_t buf, size_t n);
 
-int tekram_select(void *instance, struct timeval *timeout);
+int tekram_getfd(void *instance);
+
+gn_error tekram_changespeed(void *instance, int speed);
+void tekram_setdtrrts(void *instance, int dtr, int rts);
 
 #endif  /* __devices_tekram_h */

--- a/include/gnokii-internal.h
+++ b/include/gnokii-internal.h
@@ -39,6 +39,7 @@ do { \
 /* SMS */
 gn_error gn_sms_parse(gn_data *data);
 gn_error gn_sms_pdu2raw(gn_sms_raw *rawsms, unsigned char *pdu, int pdu_len, int flags);
+gn_error gn_sms_raw2pdu(unsigned char *buf, int *len, const gn_sms_raw *rawsms, int flags);
 gn_error gn_sms_request(gn_data *data, struct gn_statemachine *state);
 gn_error sms_prepare(gn_sms *sms, gn_sms_raw *rawsms);
 gn_timestamp *sms_timestamp_unpack(unsigned char *number, gn_timestamp *dt);

--- a/include/gnokii/data.h
+++ b/include/gnokii/data.h
@@ -197,6 +197,7 @@ typedef struct {
 	int (*select)(void *instance, struct timeval *timeout);
 	size_t (*read)(void *instance, __ptr_t buf, size_t nbytes);
 	size_t (*write)(void *instance, const __ptr_t buf, size_t n);
+	int (*getfd)(void *instance);
 	gn_error (*nreceived)(void *instance, int *n);
 	gn_error (*flush)(void *instance);
 	gn_error (*changespeed)(void *instance, int speed);
@@ -204,7 +205,6 @@ typedef struct {
 } gn_device_ops;
 
 typedef struct {
-	int fd;
 	gn_connection_type type;
 	const gn_device_ops *ops;
 	void *instance;

--- a/include/phones/nk6510.h
+++ b/include/phones/nk6510.h
@@ -46,6 +46,7 @@
 #define NK6510_MSG_TODO		0x55	/* ToDo */
 #define NK6510_MSG_FILE	        0x6d	/* File Handling */
 #define NK6510_MSG_STLOGO	0x7a	/* Startup logo */
+#define NK6510_MSG_MSGSTATUS	0xaa	/* Messaging server: send trigger + async status */
 
 /* SMS handling message subtypes (send) */
 #define NK6510_SUBSMS_SEND_SMS		0x01	/* Send SMS */
@@ -255,6 +256,10 @@ typedef struct {
 
 	/* phone model capabilities */
 	gn_phone_model *pm;
+
+	/* S40 exchange-path async send tracking */
+	unsigned sms_send_handle;
+	int sms_send_done;
 
 	/* callback local data */
 	void *cb_callback_data;		/* to be passed as callback_data to on_cell_broadcast */

--- a/xgnokii/xgnokii.c
+++ b/xgnokii/xgnokii.c
@@ -442,9 +442,9 @@ static gint Update(gpointer data)
 		(void) gmtime_r(&t, &stm);
 		strftime(timeBuf, 10, "%T", &stm);
 		if (outgoing)
-			g_snprintf(callBuf, 80, _("Outgoing call in progress:\nTime: %s"), timeBuf);
+			g_snprintf(callBuf, sizeof(callBuf), _("Outgoing call in progress:\nTime: %s"), timeBuf);
 		else
-			g_snprintf(callBuf, 80, _("Incoming call from: %s\nTime: %s"), name,
+			g_snprintf(callBuf, sizeof(callBuf), _("Incoming call from: %s\nTime: %s"), name,
 				   timeBuf);
 
 		gtk_label_set_text(GTK_LABEL(inCallDialog.label), callBuf);
@@ -589,7 +589,7 @@ static void RefreshUserStatus(void)
 		configDialogData.user.max -= 4;
 	if (GTK_ENTRY(configDialogData.user.fax)->text_length > 0)
 		configDialogData.user.max -= 4;
-	g_snprintf(buf, 8, "%d/%d", configDialogData.user.used, configDialogData.user.max);
+	g_snprintf(buf, sizeof(buf), "%d/%d", configDialogData.user.used, configDialogData.user.max);
 	gtk_label_set_text(GTK_LABEL(configDialogData.user.status), buf);
 }
 
@@ -1169,7 +1169,7 @@ static GtkWidget *CreateAboutDialog(void)
 	gtk_container_add(GTK_CONTAINER(GTK_DIALOG(dialog)->vbox), hbox);
 	gtk_widget_show(hbox);
 
-	g_snprintf(buf, 2000, _("xgnokii version: %s\ngnokii version: %s\n\n\
+	g_snprintf(buf, sizeof(buf), _("xgnokii version: %s\ngnokii version: %s\n\n\
 Copyright (C) 1999-2004 Pavel Janik ml.,\nHugh Blemings, Jan Derfinak,\n\
 Pawel Kot and others\n\
 xgnokii is free software, covered by the GNU General Public License,\n\
@@ -2072,7 +2072,7 @@ static GtkWidget *CreateOptionsDialog(void)
 		gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 3);
 		gtk_widget_show(hbox);
 
-		g_snprintf(labelBuffer, 10, _("Group %d:"), i + 1);
+		g_snprintf(labelBuffer, sizeof(labelBuffer), _("Group %d:"), i + 1);
 		label = gtk_label_new(labelBuffer);
 		gtk_box_pack_start(GTK_BOX(hbox), label, FALSE, FALSE, 2);
 		gtk_widget_show(label);

--- a/xgnokii/xgnokii_contacts.c
+++ b/xgnokii/xgnokii_contacts.c
@@ -133,7 +133,7 @@ static void RefreshEntryRow(PhonebookEntry *newPbEntry, gint row)
 	gtk_clist_set_text(GTK_CLIST(clist), row, 0, newPbEntry->entry.name);
 
 	if (newPbEntry->entry.subentries_count > 0) {
-		snprintf(string, 100, "%s *", newPbEntry->entry.number);
+		snprintf(string, sizeof(string), "%s *", newPbEntry->entry.number);
 		gtk_clist_set_text(GTK_CLIST(clist), row, 1, string);
 	} else
 		gtk_clist_set_text(GTK_CLIST(clist), row, 1, newPbEntry->entry.number);
@@ -2609,7 +2609,7 @@ static void OkExportDialog(GtkWidget * w, GtkFileSelection * fs)
 			CreateYesNoDialog(&dialog, (GtkSignalFunc) YesExportDialog, (GtkSignalFunc) CancelDialog,
 					  GUI_ContactsWindow);
 			gtk_window_set_title(GTK_WINDOW(dialog.dialog), _("Overwrite file?"));
-			g_snprintf(err, 255, _("File %s already exists.\nOverwrite?"),
+			g_snprintf(err, sizeof(err), _("File %s already exists.\nOverwrite?"),
 				   exportDialogData.fileName);
 			gtk_label_set_text(GTK_LABEL(dialog.text), err);
 		}
@@ -2967,7 +2967,7 @@ SelectContactData *GUI_SelectContactDialog(void)
 			row[0] = pbEntry->entry.name;
 
 			if (pbEntry->entry.subentries_count > 0) {
-				snprintf(string, 100, "%s *", pbEntry->entry.number);
+				snprintf(string, sizeof(string), "%s *", pbEntry->entry.number);
 				row[1] = string;
 			} else
 				row[1] = pbEntry->entry.number;

--- a/xgnokii/xgnokii_dtmf.c
+++ b/xgnokii/xgnokii_dtmf.c
@@ -73,14 +73,14 @@ static void OkLoadDialog(GtkWidget * w, GtkFileSelection * fs)
 	gtk_widget_hide(GTK_WIDGET(fs));
 
 	if ((f = fopen(fileName, "r")) == NULL) {
-		g_snprintf(buf, 80, _("Can't open file %s for reading!\n"), fileName);
+		g_snprintf(buf, sizeof(buf), _("Can't open file %s for reading!\n"), fileName);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
 		return;
 	}
 
 	if (fgets(line, MAX_DTMF_LENGTH + 1, f) == NULL) {
-		g_snprintf(buf, 80, _("Error reading file!"));
+		g_snprintf(buf, sizeof(buf), _("Error reading file!"));
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
 	} else {
@@ -115,7 +115,7 @@ static void SaveDTMF()
 	gchar buf[80];
 
 	if ((f = fopen(saveFileName, "w")) == NULL) {
-		g_snprintf(buf, 80, _("Can't open file %s for writing!\n"), saveFileName);
+		g_snprintf(buf, sizeof(buf), _("Can't open file %s for writing!\n"), saveFileName);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
 		return;
@@ -147,7 +147,7 @@ static void OkSaveDialog(GtkWidget * w, GtkFileSelection * fs)
 		if (dialog.dialog == NULL) {
 			CreateYesNoDialog(&dialog, (GtkSignalFunc) YesSaveDialog, (GtkSignalFunc) CancelDialog, GUI_DTMFWindow);
 			gtk_window_set_title(GTK_WINDOW(dialog.dialog), _("Overwrite file?"));
-			g_snprintf(err, 255, _("File %s already exists.\nOverwrite?"), saveFileName);
+			g_snprintf(err, sizeof(err), _("File %s already exists.\nOverwrite?"), saveFileName);
 			gtk_label_set_text(GTK_LABEL(dialog.text), err);
 		}
 		gtk_widget_show(dialog.dialog);
@@ -269,7 +269,7 @@ void GUI_CreateDTMFWindow()
 
 	for (i = 0; i < 3; i++)
 		for (j = 0; j < 3; j++) {
-			g_snprintf(buf, 2, "%d", j * 3 + i + 1);
+			g_snprintf(buf, sizeof(buf), "%d", j * 3 + i + 1);
 			button = gtk_button_new_with_label(buf);
 			gtk_signal_connect(GTK_OBJECT(button), "clicked",
 					   GTK_SIGNAL_FUNC(ButtonCB), (gpointer) ((gint) * buf));

--- a/xgnokii/xgnokii_logos.c
+++ b/xgnokii/xgnokii_logos.c
@@ -1331,7 +1331,7 @@ static void ExportFileSelected(GtkWidget * w, GtkFileSelection * fs)
 			CreateYesNoDialog(&dialog, (GtkSignalFunc) YesLogoFileExportDialog, (GtkSignalFunc) CancelDialog,
 					  GUI_LogosWindow);
 			gtk_window_set_title(GTK_WINDOW(dialog.dialog), _("Overwrite file?"));
-			g_snprintf(err, 255, _("File %s already exists.\nOverwrite?"),
+			g_snprintf(err, sizeof(err), _("File %s already exists.\nOverwrite?"),
 				   exportDialogData.fileName);
 			gtk_label_set_text(GTK_LABEL(dialog.text), err);
 		}

--- a/xgnokii/xgnokii_logos.c
+++ b/xgnokii/xgnokii_logos.c
@@ -977,7 +977,7 @@ void GetLogoEvent(GtkWidget * widget)
 
 	/* prepare data for event */
 	sscanf(netcou, "%s (%[^)])", network, country);
-	strncpy(bitmap.netcode, gn_network_code_find(network, country), sizeof(bitmap.netcode));
+	snprintf(bitmap.netcode, sizeof(bitmap.netcode), "%s", gn_network_code_find(network, country));
 	data->bitmap = &bitmap;
 	e->event = Event_GetBitmap;
 	e->data = data;
@@ -1019,7 +1019,7 @@ void SetLogoEvent(GtkWidget * widget)
 
 	/* prepare data */
 	sscanf(netcou, "%s (%[^)])", network, country);
-	strncpy(bitmap.netcode, gn_network_code_find(network, country), sizeof(bitmap.netcode));
+	snprintf(bitmap.netcode, sizeof(bitmap.netcode), "%s", gn_network_code_find(network, country));
 
 	if (bitmap.type == GN_BMP_CallerLogo) {
 		/* above condition must be there, because if you launch logos before
@@ -1299,7 +1299,7 @@ void ExportLogoFileMain(gchar * name)
 
 	tbitmap = bitmap;
 
-	strncpy(tbitmap.netcode, gn_network_code_get(networkInfo.network_code), sizeof(tbitmap.netcode));
+	snprintf(tbitmap.netcode, sizeof(tbitmap.netcode), "%s", gn_network_code_get(networkInfo.network_code));
 
 	error = gn_file_bitmap_save(name, &tbitmap, &statemachine->driver.phone);
 	if (error != GN_ERR_NONE) {

--- a/xgnokii/xgnokii_lowlevel.c
+++ b/xgnokii/xgnokii_lowlevel.c
@@ -1281,7 +1281,8 @@ void *GUI_Connect(void *a)
 			} else {
 				pthread_mutex_lock (&callMutex);
 				phoneMonitor.call.callInProgress = CS_Waiting;
-				strncpy (phoneMonitor.call.callNum, call->remote_number, INCALL_NUMBER_LENGTH);
+				strncpy (phoneMonitor.call.callNum, call->remote_number, INCALL_NUMBER_LENGTH - 1);
+				phoneMonitor.call.callNum[INCALL_NUMBER_LENGTH - 1] = 0;
 				pthread_mutex_unlock (&callMutex);
 			}
 		} else {

--- a/xgnokii/xgnokii_netmon.c
+++ b/xgnokii/xgnokii_netmon.c
@@ -58,7 +58,7 @@ static inline void RefreshDisplay()
 	if (!GTK_WIDGET_VISIBLE(GUI_NetmonWindow))
 		return;
 
-	g_snprintf(number, 3, "%.2d", displayData.curDisp);
+	g_snprintf(number, sizeof(number), "%.2d", displayData.curDisp);
 	if (displayData.number)
 		gtk_label_set_text(GTK_LABEL(displayData.number), number);
 

--- a/xgnokii/xgnokii_sms.c
+++ b/xgnokii/xgnokii_sms.c
@@ -615,7 +615,7 @@ static void SaveToMailbox(gchar *mailbox_name)
 
 
 	if ((f = fopen(mailbox_name, "a")) == NULL) {
-		snprintf(buf, 255, _("Cannot open mailbox %s for appending!"),
+		snprintf(buf, sizeof(buf), _("Cannot open mailbox %s for appending!"),
 			 mailbox_name);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
@@ -629,7 +629,7 @@ static void SaveToMailbox(gchar *mailbox_name)
 	lock.l_len = 0;
 
 	if (fcntl(fd, F_GETLK, &lock) != -1 && lock.l_type != F_UNLCK) {
-		snprintf(buf, 255, _("Cannot save to mailbox %s.\n\%s is locked for process %d!"),
+		snprintf(buf, sizeof(buf), _("Cannot save to mailbox %s.\n\%s is locked for process %d!"),
 			mailbox_name, mailbox_name, lock.l_pid);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
@@ -642,7 +642,7 @@ static void SaveToMailbox(gchar *mailbox_name)
 	lock.l_start = 0;
 	lock.l_len = 0;
 	if (fcntl(fd, F_SETLK, &lock) == -1) {
-		snprintf(buf, 255, _("Cannot lock mailbox %s!"), mailbox_name);
+		snprintf(buf, sizeof(buf), _("Cannot lock mailbox %s!"), mailbox_name);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
 		fclose(f);
@@ -697,7 +697,7 @@ static void SaveToMailbox(gchar *mailbox_name)
 	lock.l_start = 0;
 	lock.l_len = 0;
 	if (fcntl(fd, F_SETLK, &lock) == -1) {
-		snprintf(buf, 255, _("Cannot unlock mailbox %s!"), mailbox_name);
+		snprintf(buf, sizeof(buf), _("Cannot unlock mailbox %s!"), mailbox_name);
 		gtk_label_set_text(GTK_LABEL(errorDialog.text), buf);
 		gtk_widget_show(errorDialog.dialog);
 	}
@@ -1176,7 +1176,7 @@ static void DoSendSMS(void)
 					nr_msg = 99;
 				for (j = 0; j < nr_msg; j++) {
 					gchar header[8];
-					g_snprintf(header, 8, "%2d/%-2d: ", j + 1, nr_msg);
+					g_snprintf(header, sizeof(header), "%2d/%-2d: ", j + 1, nr_msg);
 					header[7] = '\0';
 
 					strcpy(sms.user_data[0].u.text, header);

--- a/xgnokii/xgnokii_speed.c
+++ b/xgnokii/xgnokii_speed.c
@@ -419,7 +419,7 @@ static void OkExportDialog(GtkWidget * w, GtkFileSelection * fs)
 			CreateYesNoDialog(&dialog, (GtkSignalFunc) YesExportDialog, (GtkSignalFunc) CancelDialog,
 					  GUI_SpeedDialWindow);
 			gtk_window_set_title(GTK_WINDOW(dialog.dialog), _("Overwrite file?"));
-			g_snprintf(err, 255, _("File %s already exists.\nOverwrite?"),
+			g_snprintf(err, sizeof(err), _("File %s already exists.\nOverwrite?"),
 				   exportDialogData.fileName);
 			gtk_label_set_text(GTK_LABEL(dialog.text), err);
 		}


### PR DESCRIPTION
This branch is based on the cleanup branch, github just cannot show this properly...

The objective is to make sms sending and receiving work on S40 series phones. Now it works like this:
`NK6510_SendSMS` on `model = series40`:

1. Write the bare SMS-SUBMIT **TPDU** (no SMSC — the phone supplies it) to `C:\predefmessages\exchange\<handle>` with the native file protocol (`0x6d`).
2. **Trigger** the send: phonet `0xaa`, sub-command `0x18`; the phone acks with sub-command `0x19` (status `message[4..5] == 0` = accepted).
3. **Subscribe** to the messaging channel (`0x10` subscribe listing channel `0xaa`) so the phone pushes per-message status.
4. Watch the async `0xaa/0x60` status for our handle: `state[5]` advances `01 → 07 → 02 → 07 → 05`; `0x05` ("stored/sent") means the message was handed to the SMSC/network — reported as a successful send. Delivery to the recipient is a separate delivery-report matter, not observable here (so a well-formed but undeliverable recipient succeeds just the same).

The `0x60` frames are **unsolicited** (pushed after the subscribe), so they cannot be awaited with `sm_block` (which needs a preceding request); the driver pumps `gn_sm_loop` and flags the result when the handle reaches `0x05`.

There are also some cleanup commits I did along the way — if there is something you want merge sooner, ask. I will prepare separate pull request. This one will stay Draft, there is still a work to do.

For the future reference, summary of debugging session with a help of Claude Opus 4.8 follows...

# Nokia C2-00 (RM-704) protocol notes

Reverse-engineered from Nokia PC Suite captures — C2-00 connected over USB and Bluetooth — plus `gnokii`'s own Bluetooth sessions. The Bluetooth SMS-send path was reproduced by a working prototype. The C2-00 reports model **RM-704**, SW **V 03.99**, and is a **Series 40 6th edition** device.

## 1. Summary

The phone speaks **several protocols in parallel**. Over Bluetooth they are all multiplexed onto the single phonet link `gnokii` already uses; over USB the OBEX part is a separate endpoint (see §2).

| Data / function | Protocol | Payload format |
|---|---|---|
| Phone info, model, network, battery | **native FBUS/phonet** | binary frames |
| Contacts (addressbook) | **SyncML 1.2 (OMA DS)** in phonet type `0xd9` | WBXML + vCard 2.1 |
| SMS send | write SMS-SUBMIT TPDU to the **`exchange`** folder (native file `0x6d`, *or* OBEX) + **`0xaa/0x18` trigger**; result via async **`0xaa/0x60`** status | SMS-SUBMIT TPDU |
| SMS/message read + sync | **OBEX + IrMC / SyncML** | Nokia binary / WBXML |
| Calendar | advertised (`text/x-vCalendar`, `.vcs`) but **not observed** | unconfirmed |

For SMS sending the FBUS `0x02` submit is rejected (§7). Both the **file protocol** (`0x6d`, locale-independent name `C:\predefmessages\exchange`) and OBEX (`C:\Zprávy\exchange`, Appendix H) work equivalently (both paths are alias of the same location), triggering  mechanism (§7, Appendix I) is the same (Nokia Suite is using OBEX with this phone).

## 2. Transport

### USB

`idVendor 0x0421` (Nokia), `idProduct 0x03fa`, CDC device. Two bulk endpoint pairs carry application data:

| Endpoints | Role |
|---|---|
| `0x01` OUT / `0x81` IN | FBUS / phonet (native FBUS **+** SyncML tunnel) |
| `0x04` OUT / `0x84` IN | OBEX (SMS, message store, capability, IrMC) |

### Bluetooth

**RFCOMM channel 14** = the "Nokia PC Suite" serial (FBUS/phonet) service. **Over Bluetooth, Nokia Suite muxes _everything_ — FBUS, OBEX, and SyncML — over this single phonet channel**. The phone also advertises standalone OBEX profiles (OPP ch9, FTP ch10, SyncML ch11, PBAP ch21) via SDP, but the Nokia Suite messaging path does **not** use them — it tunnels OBEX inside the phonet link.

### Transport split — USB vs Bluetooth

The muxing differs by transport:

- **USB:** two separate CDC endpoint pairs — phonet (`0x01/0x81`, FBUS + SyncML tunnel) and a dedicated OBEX endpoint (`0x04/0x84`). On USB, OBEX is *not* tunnelled in phonet.
- **Bluetooth:** one channel. OBEX **is** tunnelled in phonet as message type `0xd9`, sub-command `0x20` (block `{00 01 00 | 01 seq 00} 20 00 <raw OBEX>`); `0xd9` sub-commands `0x40/0x41/0x60/0x61/0x46/0x47/0x64` plus `0xdb` frames are the pipe open/control handshake. SyncML likewise rides `0xd9`.

Either way **SMS send works over gnokii's existing link**: gnokii uses the **file protocol** (`0x6d`) to drop the TPDU into the `exchange` folder and triggers it (Appendix I) — no OBEX pipe needed. The OBEX route to the same folder (open the `0xd9` pipe, `PUT` the TPDU — §7, Appendix H) is an equivalent alternative, also verified.

## 3. Phonet / FBUS framing

```
{ FrameID, DestDEV, SrcDEV, MsgType, LenHi, LenLo, <block[Len]> }   (no checksum)
```

| Field | Values |
|---|---|
| `FrameID` | `0x1b` DKU-2/USB · `0x19` Bluetooth · `0x14` IrDA |
| `DestDEV`/`SrcDEV` | `0x00` phone · `0x10` PC. **Messaging server replies from Src `0x60`** |
| `Len` | 16-bit big-endian, block length |

Notes:

- Info/identify server answers from Src `0x00`; the SMS subsystem answers from Src `0x60`. A strict `Src == 0x00` check drops the SMS reply (fixed in `common/links/fbus-phonet.c`).
- Native message types seen: `0x02` SMS, `0x03` phonebook, `0x0a` network status, `0x19`/`0x66`/`0xaa`/`0xdb` PCCS control, `0x1b` identify, `0xd9` SyncML tunnel.

## 4. FBUS

Phone info, model, network status (RF level / cell info) and battery use the classic `nk6510` frames and work fine. The SMS (`0x02`) and phonebook (`0x03`) paths are effectively **stubbed** on this firmware — the phone answers but the real data is in SyncML/OBEX. In particular the FBUS SMS **submit is rejected unconditionally** (see §7 example).

## 5. Contacts — SyncML 1.2 over phonet (`0xd9`)

Nokia's **PCCS (PC Connectivity Solution)** data-sync binding carries a standard SyncML 1.2 session inside phonet `0xd9` frames.

- Encoding `application/vnd.syncml+wbxml`, DTD `-//SYNCML//DTD SyncML 1.2//EN`.
- Parties: source `PCCS_Data_Sync_DESKTOP-<host>` ↔ target `IMEI:<imei>`.
- DevInf exchange `application/vnd.syncml-devinf+wbxml` (`./devinf12`).
- Datastore `/telecom/pb.vcf`, name `Contacts`, type `text/x-vcard`.
- Commands `SyncHdr` → `Alert` → `Sync` (Add/Replace) → `Status 200`.
- Payload = **vCard 2.1**.
- `0xd9` block wrapper: `00 04 00 <subcmd> 03 <data>` — `subcmd 0x20` = WBXML data (fragmented with `0x8000` markers), `0x41`/`0x47`/`0x60` = control.

## 6. SMS & messaging — OBEX + IrMC

Entirely on the OBEX channel:

- **Service discovery**: `x-obex/capability` returns an XML device object (manufacturer/model/SN/SW/memory + advertised MIME types).
- **Store layout**: `x-obex/folder-listing` over `C:\Zprávy\` ("Messages"), numbered subfolders (`\1` inbox, `\2` sent, …).
- **Synchronization**: `x-irmc/info.log` (IrMC change log) + per-record OBEX `GET`.
- **Send**: OBEX `PUT` whose End-of-Body is an SMS-SUBMIT **TPDU**.
- Message objects are Nokia binary TLV carrying the raw TPDU plus parsed UTF-16 fields (text, number).

Advertised object types in the capability: `text/x-vCard`, `text/x-vCalendar` (`.vcs`), `text/x-vMsg`, and a content list `Contacts=1 / Calendar=2 / Mess…`.

## 7. gnokii interop

| Operation | gnokii path | Result on C2-00 |
|---|---|---|
| identify / model / network / battery | native FBUS | works |
| SMS send (`--sendsms`, `model = series40`) | native `0x02` submit → **exchange file + trigger** fallback | **works** — queued and confirmed "sent" via async status (Appendix I) |
| SMS send (`--sendsms`, `model = AT`) | AT `+CMGS` PDU (BT rfcomm ch3) | **rejected** — `+CMS ERROR: 500` |
| SMS read / folders | FBUS `0x14` / `_S40_30` file path | partial (file path) |
| contacts | native FBUS `0x03` | minimal reply; real data is SyncML |

**Direct MO-SMS is rejected on every standard machine interface.** Both the FBUS `0x02` submit and the AT `+CMGS` command fail, while PC Suite sends the *same* message fine over OBEX/CONA. The AT `+CMGS` PDU is well-formed, and its `TP-DA` (`09 81 06 75 65 30 F9`) is **byte-identical** to the destination in PC Suite's successful OBEX TPDU — so the PDU/number/SMSC are provably correct. `+CMS ERROR: 500` is the spec's generic "unknown error": the phone's SMS stack simply refuses the submission. The SIM/network/SMSC all work (Nokia Suite proves it), so this seems to be **firmware-level restriction**: the C2-00 routes outbound SMS only through its messaging app (driven via CONA/OBEX), not the raw AT/FBUS submit paths.

Consequences for gnokii:

- Phone rejects `0x02`/`+CMGS` transports, not the content.
- **SMS send is implemented** on `model = series40` via the exchange path, this is 3rd edition way. The OBEX route to the same folder (Appendix H) is what's Nokia Suite is using and should be used for 6th edition phones.
- Contacts could ride the same phonet link via the `0xd9` SyncML tunnel.

## 8. PC Suite component map (from the Windows binaries)

Confirmed by inspecting the Nokia Suite install, matching the wire behaviour above. Useful as a map if the protocol is ever implemented; note that the wire-level framing itself is not stored as plaintext in these DLLs and would need real disassembly (Ghidra/radare2 — `objdump` alone is inadequate for the MSVC x64 Qt C++ code) or, more cheaply, further known-plaintext captures.

| Component | Role |
|---|---|
| `MFileSystemTransfer.dll` | **CONA** file system over **OBEX** (`CNCONAFileSystem`, `x-obex/capability`) — the messaging/file-store client |
| `ilsyncEx.dll`, `IlSdk.fil` | **Intellisync** engine — SyncML for PIM |
| `MTransfer.dll`, `MMSParser.dll` | SyncML / message parsing |
| `DAL.dll` | Qt "Device Access Layer" — USB/Bluetooth/Ovi connection handling and sync orchestration (`onUSBConnected`, `onBluetoothConnected`, `SyncFromDeviceMsg`) |
| `CDC.dll` | CDC-ACM serial transport |
| Driver stack `nmwcd*` / `ccdcmb*` (Connectivity Cable Driver) | USB CDC interface enumeration; likely host of the low-level phonet/OBEX framing |

Takeaways: messaging is **CONA-over-OBEX**, PIM is **Intellisync/SyncML**, both under a Qt orchestration layer — i.e. the two-engine split of §1 is a deliberate product architecture, not an artefact of one capture. The `text/x-vMsg`, `text/x-vCard`, `text/x-vCalendar` object types are the CONA/OBEX capability set.

---

# Appendix — decoded frame examples

Bytes are on-the-wire; `19` = Bluetooth FrameID (`1b` over USB DKU-2). `. ` in ASCII columns = non-printable.

## A. Identify / GetModel (native FBUS `0x1b`)

```
TX  19 00 10 1b 00 06  00 01 00 07 01 00
    │  │  │  │  └──┴ len=6
    │  │  │  └ MsgType 0x1b (identify)
    │  │  └ Src 0x10 (PC)
    │  └ Dest 0x00 (phone)
    └ FrameID

RX  19 10 00 1b 00 3a  01 4b 00 08 00 01 58 34 00 30 56 20 30 33 2e 39 39 0a ...
                              │        └ payload: "…V 03.99\n03-04-12\nRM-704\n(c) Nokia…"
                              └ subtype 0x08 (identify reply)
```

## B. SMS submit over native FBUS — rejected (`0x02`)

```
TX  19 00 10 02 00 37   (block, 55 B)
    00 01 00 02 00 00 00 55 55 01 02 2d 11 00 00 00 00 04
    82 0c 01 07 09 81 06 75 65 30 f9 00      ← recipient subblock (TP-DA, masked)
    82 0d 02 09 08 81 <smsc semi-octets> 00  ← SMSC subblock
    80 08 04 04 f4 f2 9c 0e                  ← user-data subblock ("test", 7-bit)
    08 04 01 a9                              ← validity subblock

RX  19 10 60 02 00 0a  01 a6 00 03 00 02 19 00 00 00
       │  │        │  └──┴ len=10
       │  │        └ MsgType 0x02
       │  └ Src 0x60  ← messaging server (NOT 0x00)
       └ Dest 0x10
    block: subtype 0x03 = send status — here a rejection: len 10, no reference
    field, message[8]=0x00 (identical to the documented "sent OK", so useless as
    a discriminator). message[6] (here 0x19) is NOT a cause: it is a running
    message-store index that increments (0x19, 0x2b, 0x2c, …) as messages
    accumulate and is the same for a valid and an invalid recipient. Rejection is
    invariant across no-SMSC / national / international SMSC. gnokii treats the
    short 0x03 reply as failure and falls back to the exchange path (Appendix I).
```

## C. Network status (native FBUS `0x0a`)

```
RF level (subtype 0x1e):
  19 10 00 0a 00 0a  01 86 ff 1e 64 41 00 00 00 00
                                 │  └ message[4]=0x64=100 → RF level 100
                                 └ subtype 0x1e

Cell/network info (subtype 0xb6) — unsolicited broadcast once subscribed:
  19 10 00 0a 00 12  01 86 ff b6 64 41 00 00 00 02 e8 04 00 02 e9 04 00 60
                                 │  │           └ serving/neighbour cell ids 0x04e8/0x04e9
                                 │  └ RF level 100 (same offset as 0x1e)
                                 └ subtype 0xb6 (was "UNHANDLED FRAME" spam; now consumed)
```

## D. Contacts — SyncML tunneled in phonet `0xd9`

```
phonet:  1b 00 10 d9 <lenhi lenlo>  00 04 00 20 03 80 00 15 <WBXML…>
                                    └ 0xd9 wrapper: subcmd 0x20 = WBXML data

WBXML (decoded tokens):
  application/vnd.syncml+wbxml   -//SYNCML//DTD SyncML 1.2//EN   SyncML/1.2
  source  PCCS_Data_Sync_DESKTOP-<host>
  target  IMEI:<imei>
  devinf  application/vnd.syncml-devinf+wbxml   ./devinf12
  datastore  /telecom/pb.vcf   name "Contacts"   type text/x-vcard
  Status 200
```

vCard item (contact data redacted):

```
BEGIN:VCARD
VERSION:2.1
N;CHARSET=UTF-8;ENCODING=8BIT:<Surname>;<Given>
TEL;PREF;VOICE;ENCODING=8BIT:+420XXXXXXXXX
END:VCARD
```

## E. SMS submit over OBEX (the path that actually delivers)

```
OBEX PUT(final), 170 bytes:
  82 00 aa                         PUT(final), len 170
  cb 00 00 00 02                   Connection-Id = 2
  01 00 6b <UTF-16 name … number>  Name = record id + destination number
  c3 00 00 00 12                   Length = 18
  44 00 12 "20260730T160711J"      Time header
  00 0b "PC Suite"                 service
  49 00 15                         End-of-Body (18 B) = SMS-SUBMIT TPDU:
       11              first octet (MTI=SUBMIT, VPF=relative)
       00              TP-MR
       09 81 <BCD…>    TP-DA: 9 digits, type 0x81 (number masked)
       00              TP-PID
       00              TP-DCS (7-bit default)
       ff              TP-VP
       05              TP-UDL = 5
       f0 f7 ba 3e 07  user data, 7-bit packed  → "pokus"
```

The TPDU tail matches what `gnokii`'s `NK6510_SendSMS` already builds — only the transport (OBEX vs FBUS `0x02`) differs.

## F. OBEX capability / message store (IrMC)

```
GET x-obex/capability →
  <Capability><General><Manufacturer>Nokia</Manufacturer><Model>RM-704</Model>
  <SN><imei-masked></SN><SW Version="V 03.99" Date="20120403T120000"/>
  <Language>cs</Language> … <XNam>ModelName</XNam><XVal>C2-00</XVal> …
  <Object><Type>text/x-vCalendar</Type><Name-Ext>vcs</Name-Ext></Object> …

GET x-obex/folder-listing on C:\Zprávy\ → per-message records fetched by handle:
  2\0000029F57659BD5003A2010005000000020100…04206XXXXXXX…    (folder 2 = sent)
  1\00000360579CB48F00002012002…0<number>XXX00000012        (folder 1 = inbox)

IrMC sync log: x-irmc/info.log
```

## G. SMS submit over the AT modem — rejected (`model = AT`)

Bluetooth RFCOMM channel 3 (the AT/modem service). PDU mode.

```
→ AT+CMGF=0                     OK          (PDU mode)
→ AT+CMGS=17                    "> "        (17 = TPDU length, excl. SMSC)
→ 07 91 24 60 30 50 02 00       SMSC: type 0x91, +420603052000
  11 00 09 81 06 75 65 30 F9    TPDU: SUBMIT, TP-DA type 0x81, 605756039
  00 00 A9 04 F4 F2 9C 0E       PID 00, DCS 00 (7-bit), VP A9, UDL 4, "test"
  <Ctrl-Z>
← +CMS ERROR: 500              generic "unknown error"
```

The `TP-DA` (`09 81 06 75 65 30 F9`) is byte-identical to Appendix E's OBEX TPDU that PC Suite delivered successfully — so the content is correct and only the transport is refused.

## H. Bluetooth SMS send over the phonet 0xd9 OBEX tunnel (VERIFIED)

Reconstructed from `c2-00-bt.pcapng` / `c2-00-bt-smsonly.pcapng` and confirmed by a working prototype (delivered real messages). The whole exchange rides RFCOMM channel 14 (the "Nokia PC Suite" serial service) — the same link gnokii uses.

### H.1 Pipe-open handshake (phonet frames)

Frames are `19 <dst> <src> <type> <len16> <block>`; `dst/src` `00`=phone `10`=PC.

```
OUT 0xd0 [04]                                    init (gnokii phonet_open already sends this)
IN  0xd0 [05]
OUT 0xdb [00 01 00 05 00 00 01 08 05 d9 10 01 00 00]   create OBEX pipe (media 0xd9)
IN  0xdb [01 00 00 06 00]
IN  0xd9 sub=0x40                                phone: pipe-created
OUT 0xd9 sub=0x41 [00 01 00 41 00 00]
IN  0xd9 sub=0x61
OUT 0xd9 sub=0x60 [00 01 00 60 00 05 01 00 00 ff ff]
IN  0xd9 sub=0x60 (+padding)  then  IN 0xd9 sub=0x46
OUT 0xd9 sub=0x47 [00 01 00 47 00 00]
IN  0xd9 sub=0x64
-- pipe open; OBEX now flows in 0xd9 sub-command 0x20 --
```

Tunnel wrapper for OBEX: block = `{00 01 00 | 01 seq 00} 20 00 <raw OBEX>`.

### H.2 OBEX exchange (inside the 0xd9/0x20 pipe)

```
CONNECT   ver 10 flags 00 mtu 2000
          Target 0x46 = f9ec7bc4-953c-11d2-984e-525400dc9e09 (Folder-Browsing)
          Who    0x4a = "PC Suite"                             -> 0xA0, Connection-Id 1
SETPATH   ""            (root)                                 -> 0xA0
SETPATH   "C:\Zprávy"   (Messages)                             -> 0xA0
SETPATH   "exchange"                                           -> 0xA0
PUT(final)
   ConnId 0xcb = 00000001
   Name   0x01 = 00000002<msgid8hex>000021000700000001010000<len2><number>
   Length 0xc3 = <len(TPDU)>
   Time   0x44 = "YYYYMMDDTHHMMSS"
   Who    0x4a = "PC Suite"
   EoB    0x49 = SMS-SUBMIT TPDU (no SMSC; phone supplies it), e.g.
                 11 00 09 81 06 75 65 30 f9 00 00 ff 04 f4 f2 9c 0e   ("test" -> 605756039)
   -> 0xA0 SUCCESS; phone submits to the network.
```

Notes:

- Only **one** OBEX connection (Folder-Browsing) is used — **no SyncML session is required to send**.
- `msgid8hex` is an incrementing message id (`579f5b8a`, `579f692c`, … seen); an arbitrary fresh value works (a duplicate is deduped and not resent).
- The TPDU is exactly what `NK6510_SendSMS` builds; only the SMSC prefix is omitted (the phone adds its configured SMSC).
- Delivery is asynchronous — the phone may queue briefly before sending. PC Suite confirms success by reading the message status back afterwards (optional).

## I. Implemented send path — file + trigger + async status (VERIFIED)

This is what gnokii's `nk6510` driver does on `model = series40`, verified on RM-704 with `--sendsms`. It reaches the same `exchange` folder as the OBEX route (Appendix H) but over the **FBUS file protocol** — no OBEX pipe needed — using the locale-independent name `C:\predefmessages\exchange` (the OBEX name `C:\Zprávy\exchange` is the localized alias of the same folder).

### I.1 Native submit rejected (Appendix B), then write the TPDU (file proto `0x6d`)

```
-- open C:\predefmessages\exchange\<handle> for writing --
OUT 0x6d  00 01 00 72 11 00 00 <len> 00 43 00 3a 00 5c 00 70 …    (subtype 0x72 = open)
          path (UTF-16) = "C:\predefmessages\exchange\<handle>"
          handle = 00000002<msgid8hex>000021000700000001010000<numlen><number>
          <number> is the recipient with a leading '+' for an international
          number (type 0x91); <numlen> is its length incl. the '+' (e.g.
          "13+420605604603"). The TPDU's TP-DA carries the same number.
IN  0x6d  01 50 00 73 00 00 00 00 <fh16>                          (file handle)
-- write the TPDU, then close --
OUT 0x6d  00 01 00 58 00 00 00 00 <fh16> 00 00 00 <n> <TPDU>      (subtype 0x58 = write)
IN  0x6d  01 50 00 59 00 00
OUT 0x6d  00 01 00 74 00 00 00 00 <fh16>                          (subtype 0x74 = close)
IN  0x6d  01 50 00 75 00 00
```

TPDU = bare SMS-SUBMIT (no SMSC), e.g. `11 00 09 81 06 75 65 30 f9 00 00 a9 02 e8 34` (SUBMIT, TP-DA 605756039, PID 00, DCS 00 7-bit, VP a9, UDL 2, "hi").

### I.2 Trigger the send (`0xaa/0x18`) and its ack (`0x19`)

```
OUT 0xaa  00 01 01 18 00 00
IN  0xaa  01 7d 01 19 00 00      0x18→0x19 ack; status message[4..5]=00 00 = accepted
```

### I.3 Subscribe to the messaging-status channel (`0x10`)

```
OUT 0x10  00 01 00 10 07 01 02 0a 14 15 17 aa
              │        └ count 7, channels 01 02 0a 14 15 17 aa  (0xaa = messaging status)
              └ subtype 0x10 = subscribe
```

Without this the phone sends only the `0x19` trigger ack and no status at all. PC Suite subscribes the same way (`00 <seq> 00 10 02 66 aa`).

### I.4 Async per-message status (`0xaa/0x60`), pushed

```
IN 0xaa 01 7d 00 60 00 <st> 00 00 00 02 00 02 00 3c 02 02 02 01 <y> 02 …
        … 03 <slot> <handle:4> … 23 00 08 <..> 00 00
   [3]=0x60   messaging subsystem
   [5]=<st>   message state ;  [37]=<slot> outbox slot ;  [38..41]=<handle> = our msgid
   state[5] of a send:  01 → 07 → 02 → 07 → 05
        0x07 = stored/not-sent (outbox) ,  0x05 = stored/sent (handed to network)
```

`state[5] == 0x05` for our handle = success. Also pushed on **type `0x02`** during the send (all Src `0x60`): `0x22` "trying to send it" (TP reference at `message[5]`), `0x4b` message info (full TPDU + references), `0x48` send report.

These `0x60` frames are unsolicited, so gnokii pumps `gn_sm_loop` and flags on `0x05` rather than using `sm_block`. Verified: a valid number and an invalid number recipient both progress `01→07→02→07→05` and report success — `0x05` = handed to the SMSC/network; non-delivery to a bogus number is a delivery-report matter not visible at send time.